### PR TITLE
Introduce SIMS worker

### DIFF
--- a/cmd/gateway-http/gateway-http.go
+++ b/cmd/gateway-http/gateway-http.go
@@ -75,8 +75,7 @@ var (
 
 func main() {
 	var (
-		begin       = time.Now()
-		hostname, _ = os.Hostname()
+		begin = time.Now()
 
 		awsID         = flag.String("aws.id", "", "Identifier for AWS requests")
 		awsRegion     = flag.String("aws.region", "us-east-1", "AWS Region to operate in")

--- a/cmd/sims/channel.go
+++ b/cmd/sims/channel.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/platform/sns"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/device"
+)
+
+type channelFunc func(*app.App, *message) error
+
+func channelPush(
+	deviceListUser core.DeviceListUserFunc,
+	deviceSync core.DeviceSyncEndpointFunc,
+	push sns.PushFunc,
+	pApps platformApps,
+) channelFunc {
+	return func(currentApp *app.App, msg *message) error {
+		ds, err := deviceListUser(currentApp, msg.recipient)
+		if err != nil {
+			return err
+		}
+		if len(ds) == 0 {
+			return nil
+		}
+
+		for _, d := range ds {
+			pa, err := platformAppForPlatform(pApps, currentApp, d.Platform)
+			if err != nil {
+				if isPlatformNotFound(err) {
+					continue
+				}
+				return err
+			}
+
+			d, err = deviceSync(currentApp, pa.ARN, d)
+			if err != nil {
+				return err
+			}
+
+			var p sns.Platform
+
+			switch d.Platform {
+			case device.PlatformAndroid:
+				p = sns.PlatformGCM
+			case device.PlatformIOS:
+				p = sns.PlatformAPNS
+			case device.PlatformIOSSandbox:
+				p = sns.PlatformAPNSSandbox
+			}
+
+			err = push(p, d.EndpointARN, pa.Scheme, msg.urn, msg.message)
+			if err != nil {
+				if sns.IsDeliveryFailure(err) {
+					return nil
+				}
+
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/cmd/sims/consume.go
+++ b/cmd/sims/consume.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/platform/sns"
+	platformSQS "github.com/tapglue/snaas/platform/sqs"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/connection"
+	"github.com/tapglue/snaas/service/event"
+	"github.com/tapglue/snaas/service/object"
+)
+
+type ackFunc func() error
+
+type batch struct {
+	ackFunc  ackFunc
+	app      *app.App
+	messages messages
+}
+
+type message struct {
+	message   string
+	recipient uint64
+	urn       string
+}
+
+type messages []*message
+
+func consumeConnection(
+	appFetch core.AppFetchFunc,
+	conSource connection.Source,
+	batchc chan<- batch,
+	ruleFns ...conRuleFunc,
+) error {
+	for {
+		c, err := conSource.Consume()
+		if err != nil {
+			if connection.IsEmptySource(err) {
+				continue
+			}
+			return err
+		}
+
+		currentApp, err := appForNamespace(appFetch, c.Namespace)
+		if err != nil {
+			return err
+		}
+
+		ms := messages{}
+
+		for _, rule := range ruleFns {
+			msgs, err := rule(currentApp, c)
+			if err != nil {
+				return err
+			}
+
+			for _, msg := range msgs {
+				ms = append(ms, msg)
+			}
+		}
+
+		if len(ms) == 0 {
+			err := conSource.Ack(c.AckID)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		batchc <- batchMessages(currentApp, conSource, c.AckID, ms)
+	}
+}
+
+func consumeEndpointChange(
+	api platformSQS.API,
+	queueURL string,
+	changec chan endpointChange,
+) error {
+	for {
+		o, err := platformSQS.ReceiveMessage(api, queueURL)
+		if err != nil {
+			return err
+		}
+
+		for _, msg := range o.Messages {
+			ack := func() error {
+				_, err := api.DeleteMessage(&sqs.DeleteMessageInput{
+					QueueUrl:      aws.String(queueURL),
+					ReceiptHandle: msg.ReceiptHandle,
+				})
+				return err
+			}
+
+			if msg.Body == nil {
+				_ = ack()
+
+				continue
+			}
+
+			f := struct {
+				Message string `json:"Message"`
+				Type    string `json:"Type"`
+			}{}
+
+			if err := json.Unmarshal([]byte(*msg.Body), &f); err != nil {
+				return err
+			}
+
+			if f.Type != sns.TypeNotification {
+				_ = ack()
+
+				continue
+			}
+
+			c := endpointChange{}
+
+			if err := json.Unmarshal([]byte(f.Message), &c); err != nil {
+				return err
+			}
+
+			c.ack = ack
+
+			changec <- c
+		}
+	}
+}
+func consumeEvent(
+	appFetch core.AppFetchFunc,
+	eventSource event.Source,
+	batchc chan<- batch,
+	ruleFns ...eventRuleFunc,
+) error {
+	for {
+		c, err := eventSource.Consume()
+		if err != nil {
+			if event.IsEmptySource(err) {
+				continue
+			}
+			return err
+		}
+
+		currentApp, err := appForNamespace(appFetch, c.Namespace)
+		if err != nil {
+			return err
+		}
+
+		ms := messages{}
+
+		for _, rule := range ruleFns {
+			rs, err := rule(currentApp, c)
+			if err != nil {
+				return err
+			}
+
+			for _, msg := range rs {
+				ms = append(ms, msg)
+			}
+		}
+
+		if len(ms) == 0 {
+			err = eventSource.Ack(c.AckID)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		batchc <- batchMessages(currentApp, eventSource, c.AckID, ms)
+	}
+}
+
+func consumeObject(
+	appFetch core.AppFetchFunc,
+	objectSource object.Source,
+	batchc chan<- batch,
+	ruleFns ...objectRuleFunc,
+) error {
+	for {
+		c, err := objectSource.Consume()
+		if err != nil {
+			if object.IsEmptySource(err) {
+				continue
+			}
+			return err
+		}
+
+		currentApp, err := appForNamespace(appFetch, c.Namespace)
+		if err != nil {
+			return err
+		}
+
+		ms := messages{}
+
+		for _, rule := range ruleFns {
+			rs, err := rule(currentApp, c)
+			if err != nil {
+				return err
+			}
+
+			for _, msg := range rs {
+				ms = append(ms, msg)
+			}
+		}
+
+		if len(ms) == 0 {
+			err := objectSource.Ack(c.AckID)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		batchc <- batchMessages(currentApp, objectSource, c.AckID, ms)
+	}
+}
+
+func batchMessages(
+	currentApp *app.App,
+	acker platformSQS.Acker,
+	ackID string,
+	ms messages,
+) batch {
+	return batch{
+		ackFunc: func(acked bool, ackID string) ackFunc {
+			return func() error {
+				if acked {
+					return nil
+				}
+
+				err := acker.Ack(ackID)
+				if err == nil {
+					acked = true
+				}
+				return err
+			}
+		}(false, ackID),
+		app:      currentApp,
+		messages: ms,
+	}
+}

--- a/cmd/sims/endpoint.go
+++ b/cmd/sims/endpoint.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/platform/sns"
+	"github.com/tapglue/snaas/service/app"
+)
+
+const serviceSNS = "SNS"
+
+type endpointChange struct {
+	ack            ackFunc
+	EndpointArn    string `json:"EndpointArn"`
+	EventType      string `json:"EventType"`
+	FailureMessage string `json:"FailureMessage"`
+	FailureType    string `json:"FailureType"`
+	Resource       string `json:"Resource"`
+	Service        string `json:"Service"`
+}
+
+func endpointUpdate(
+	disableDevice core.DeviceDisableFunc,
+	currentApp *app.App,
+	c endpointChange,
+) (err error) {
+	defer func() {
+		if err == nil {
+			c.ack()
+		}
+	}()
+
+	if c.Service != serviceSNS {
+		return nil
+	}
+
+	if c.EventType != sns.TypeDeliveryFailure {
+		return nil
+	}
+
+	return disableDevice(currentApp, c.EndpointArn)
+}

--- a/cmd/sims/platform.go
+++ b/cmd/sims/platform.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/device"
+)
+
+var (
+	ErrInvalidNamespace = errors.New("namespace invalid")
+	ErrPlatformNotFound = errors.New("platform not found")
+)
+
+type platformApp struct {
+	ARN       string `json:"arn"`
+	Namespace string `json:"namespace"`
+	Scheme    string `json:"scheme"`
+	Platform  int    `json:"platform"`
+}
+
+type platformApps []*platformApp
+
+func (as *platformApps) Set(input string) error {
+	a := &platformApp{}
+	err := json.Unmarshal([]byte(input), a)
+	if err != nil {
+		return err
+	}
+
+	*as = append(*as, a)
+
+	return nil
+}
+
+func (as *platformApps) String() string {
+	return fmt.Sprintf("%d apps", len(*as))
+}
+
+func appForARN(
+	appFetch core.AppFetchFunc,
+	pApps platformApps,
+	pARN string,
+) (*app.App, error) {
+	var a *platformApp
+
+	for _, pa := range pApps {
+		if pa.ARN == pARN {
+			a = pa
+			break
+		}
+	}
+
+	if a == nil {
+		return nil, ErrPlatformNotFound
+	}
+
+	id, err := namespaceToID(a.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return appFetch(id)
+}
+
+func appForNamespace(appFetch core.AppFetchFunc, ns string) (*app.App, error) {
+	id, err := namespaceToID(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	return appFetch(id)
+}
+
+func namespaceToID(ns string) (uint64, error) {
+	ps := strings.SplitN(ns, "_", 2)
+
+	if len(ps) != 2 {
+		return 0, ErrInvalidNamespace
+	}
+
+	return strconv.ParseUint(ps[1], 10, 64)
+}
+
+func isPlatformNotFound(err error) bool {
+	return err == ErrPlatformNotFound
+}
+
+func platformAppForPlatform(
+	pApps platformApps,
+	a *app.App,
+	p device.Platform,
+) (*platformApp, error) {
+	var pApp *platformApp
+
+	for _, pa := range pApps {
+		if pa.Namespace == a.Namespace() && device.Platform(pa.Platform) == p {
+			pApp = pa
+			break
+		}
+	}
+
+	if pApp == nil {
+		return nil, ErrPlatformNotFound
+	}
+
+	return pApp, nil
+}

--- a/cmd/sims/rules.go
+++ b/cmd/sims/rules.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/connection"
+	"github.com/tapglue/snaas/service/event"
+	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/user"
+)
+
+// Messaging.
+const (
+	fmtCommentPost     = `%s commented on a Post.`
+	fmtCommentPostOwn  = `%s commented on your Post.`
+	fmtFollow          = `%s started following you`
+	fmtFriendConfirmed = `%s accepted your friend request.`
+	fmtFriendRequest   = `%s sent you a friend request.`
+	fmtLikePost        = `%s liked a Post.`
+	fmtLikePostOwn     = `%s liked your Post.`
+	fmtPostCreated     = `%s created a new Post.`
+)
+
+// Deep-linking URNs.
+const (
+	urnComment = `tapglue/posts/%d/comments/%d`
+	urnPost    = `tapglue/posts/%d`
+	urnUser    = `tapglue/users/%d`
+)
+
+type conRuleFunc func(*app.App, *connection.StateChange) (messages, error)
+type eventRuleFunc func(*app.App, *event.StateChange) (messages, error)
+type objectRuleFunc func(*app.App, *object.StateChange) (messages, error)
+
+func conRuleFollower(userFetch core.UserFetchFunc) conRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *connection.StateChange,
+	) (messages, error) {
+		if change.Old != nil ||
+			change.New.State != connection.StateConfirmed ||
+			change.New.Type != connection.TypeFollow {
+			return nil, nil
+		}
+
+		origin, err := userFetch(currentApp, change.New.FromID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		target, err := userFetch(currentApp, change.New.ToID)
+		if err != nil {
+			return nil, fmt.Errorf("target fetch: %s", err)
+		}
+
+		return messages{
+			{
+				message:   fmtToMessage(fmtFollow, origin),
+				recipient: target.ID,
+				urn:       fmt.Sprintf(urnUser, origin.ID),
+			},
+		}, nil
+	}
+}
+
+func conRuleFriendConfirmed(userFetch core.UserFetchFunc) conRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *connection.StateChange,
+	) (messages, error) {
+		if change.Old == nil ||
+			change.Old.Type != connection.TypeFriend ||
+			change.New.State != connection.StatePending ||
+			change.New.Type != connection.TypeFriend {
+			return nil, nil
+		}
+
+		origin, err := userFetch(currentApp, change.New.FromID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		target, err := userFetch(currentApp, change.New.ToID)
+		if err != nil {
+			return nil, fmt.Errorf("target fetch: %s", err)
+		}
+
+		return messages{
+			{
+				message:   fmtToMessage(fmtFriendConfirmed, target),
+				recipient: origin.ID,
+				urn:       fmt.Sprintf(urnUser, origin.ID),
+			},
+		}, nil
+	}
+}
+
+func conRuleFriendRequest(userFetch core.UserFetchFunc) conRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *connection.StateChange,
+	) (messages, error) {
+		if change.Old != nil ||
+			change.New.State != connection.StatePending ||
+			change.New.Type != connection.TypeFriend {
+			return nil, nil
+		}
+
+		origin, err := userFetch(currentApp, change.New.FromID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		target, err := userFetch(currentApp, change.New.ToID)
+		if err != nil {
+			return nil, fmt.Errorf("target fetch: %s", err)
+		}
+
+		return messages{
+			{
+				message:   fmtToMessage(fmtFriendRequest, origin),
+				recipient: target.ID,
+				urn:       fmt.Sprintf(urnUser, origin.ID),
+			},
+		}, nil
+	}
+}
+
+func eventRuleLikeCreated(
+	followerIDs core.ConnectionFollowerIDsFunc,
+	friendIDs core.ConnectionFriendIDsFunc,
+	postFetch core.PostFetchFunc,
+	userFetch core.UserFetchFunc,
+	usersFetch core.UsersFetchFunc,
+) eventRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *event.StateChange,
+	) (messages, error) {
+		if change.Old != nil ||
+			change.New.Enabled == false ||
+			!core.IsLike(change.New) {
+			return nil, nil
+		}
+
+		post, err := postFetch(currentApp, change.New.ObjectID)
+		if err != nil {
+			return nil, fmt.Errorf("post fetch: %s", err)
+		}
+
+		origin, err := userFetch(currentApp, change.New.UserID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		owner, err := userFetch(currentApp, post.OwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("owner fetch: %s", err)
+		}
+
+		followIDs, err := followerIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		fIDs, err := friendIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		ids := filterIDs(append(followIDs, fIDs...), owner.ID)
+
+		rs, err := usersFetch(currentApp, ids...)
+		if err != nil {
+			return nil, err
+		}
+
+		rs = append(rs, owner)
+		ms := messages{}
+
+		for _, recipient := range rs {
+			f := fmtLikePost
+
+			if post.OwnerID == recipient.ID {
+				f = fmtLikePostOwn
+			}
+
+			ms = append(ms, &message{
+				message:   fmtToMessage(f, origin),
+				recipient: recipient.ID,
+				urn:       fmt.Sprintf(urnPost, post.ID),
+			})
+		}
+
+		return ms, nil
+	}
+}
+
+func objectRuleCommentCreated(
+	followerIDs core.ConnectionFollowerIDsFunc,
+	friendIDs core.ConnectionFriendIDsFunc,
+	postFetch core.PostFetchFunc,
+	userFetch core.UserFetchFunc,
+	usersFetch core.UsersFetchFunc,
+) objectRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *object.StateChange,
+	) (messages, error) {
+		if change.Old != nil ||
+			change.New.Deleted == true ||
+			!core.IsComment(change.New) {
+			return nil, nil
+		}
+
+		post, err := postFetch(currentApp, change.New.ObjectID)
+		if err != nil {
+			return nil, fmt.Errorf("post fetch: %s", err)
+		}
+
+		origin, err := userFetch(currentApp, change.New.OwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		owner, err := userFetch(currentApp, post.OwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("owner fetch: %s", err)
+		}
+
+		followIDs, err := followerIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		fIDs, err := friendIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		ids := filterIDs(append(followIDs, fIDs...), owner.ID)
+
+		rs, err := usersFetch(currentApp, ids...)
+		if err != nil {
+			return nil, err
+		}
+
+		rs = append(rs, owner)
+		ms := messages{}
+
+		for _, recipient := range rs {
+			f := fmtCommentPost
+
+			if post.OwnerID == recipient.ID {
+				f = fmtCommentPostOwn
+			}
+
+			ms = append(ms, &message{
+				message:   fmtToMessage(f, origin),
+				recipient: recipient.ID,
+				urn:       fmt.Sprintf(urnComment, post.ID, change.New.ID),
+			})
+		}
+
+		return ms, nil
+	}
+}
+
+func objectRulePostCreated(
+	followerIDs core.ConnectionFollowerIDsFunc,
+	friendIDs core.ConnectionFriendIDsFunc,
+	userFetch core.UserFetchFunc,
+	usersFetch core.UsersFetchFunc,
+) objectRuleFunc {
+	return func(
+		currentApp *app.App,
+		change *object.StateChange,
+	) (messages, error) {
+		if change.Old != nil ||
+			change.New.Deleted == true ||
+			!core.IsPost(change.New) {
+			return nil, nil
+		}
+
+		origin, err := userFetch(currentApp, change.New.OwnerID)
+		if err != nil {
+			return nil, fmt.Errorf("origin fetch: %s", err)
+		}
+
+		followIDs, err := followerIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		fIDs, err := friendIDs(currentApp, origin.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		rs, err := usersFetch(currentApp, append(followIDs, fIDs...)...)
+		if err != nil {
+			return nil, err
+		}
+
+		ms := messages{}
+
+		for _, recipient := range rs {
+			ms = append(ms, &message{
+				message:   fmtToMessage(fmtPostCreated, origin),
+				recipient: recipient.ID,
+				urn:       fmt.Sprintf(urnPost, change.New.ID),
+			})
+		}
+
+		return ms, nil
+	}
+}
+
+func filterIDs(ids []uint64, fs ...uint64) []uint64 {
+	var (
+		is   = []uint64{}
+		seen = map[uint64]struct{}{}
+	)
+
+	for _, id := range fs {
+		seen[id] = struct{}{}
+	}
+
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		is = append(is, id)
+	}
+
+	return is
+}
+
+func fmtToMessage(f string, u *user.User) string {
+	if u.Firstname != "" {
+		return fmt.Sprintf(f, u.Firstname)
+	}
+
+	return fmt.Sprintf(f, u.Username)
+}

--- a/cmd/sims/sims.go
+++ b/cmd/sims/sims.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"flag"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awsSession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/go-kit/kit/log"
+	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/platform/metrics"
+	platformSNS "github.com/tapglue/snaas/platform/sns"
+	platformSQS "github.com/tapglue/snaas/platform/sqs"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/connection"
+	"github.com/tapglue/snaas/service/device"
+	"github.com/tapglue/snaas/service/event"
+	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/user"
+)
+
+// Logging and telemetry identifiers.
+const (
+	component        = "sims"
+	namespaceService = "service"
+	namespaceSource  = "source"
+	source           = "sqs"
+	storeService     = "postgres"
+	subsystemQueue   = "queue"
+)
+
+// Queue names.
+const (
+	queueEndpointChanges = "endpoint-changes"
+)
+
+// Buildtime vars.
+var (
+	revision = "0000000-dev"
+)
+
+func main() {
+	var (
+		begin = time.Now()
+		pApps = platformApps{}
+
+		awsKey        = flag.String("aws.key", "", "Identifier for AWS requests")
+		awsRegion     = flag.String("aws.region", "us-east-1", "AWS region to operate in")
+		awsSecret     = flag.String("aws.secret", "", "Identification secret for AWS requests")
+		postgresURL   = flag.String("postgres.url", "", "Postgres URL to connect to")
+		telemetryAddr = flag.String("telemetry.addr", ":9001", "Address to expose telemetry on")
+	)
+	flag.Var(&pApps, "app", "Repeated platform apps.")
+	flag.Parse()
+
+	logger := log.NewContext(
+		log.NewJSONLogger(os.Stdout),
+	).With(
+		"caller", log.Caller(3),
+		"component", component,
+		"revision", revision,
+	)
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+	}
+
+	logger = log.NewContext(logger).With("host", hostname)
+
+	// Setup instrumentation.
+	go func(addr string) {
+		logger.Log(
+			"duration", time.Now().Sub(begin).Nanoseconds(),
+			"lifecycle", "start",
+			"listen", addr,
+			"sub", "telemetry",
+		)
+
+		http.Handle("/metrics", prometheus.Handler())
+
+		err := http.ListenAndServe(addr, nil)
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort", "sub", "telemetry")
+			os.Exit(1)
+		}
+	}(*telemetryAddr)
+
+	serviceErrCount, serviceOpCount, serviceOpLatency := metrics.KeyMetrics(
+		namespaceService,
+		metrics.FieldComponent,
+		metrics.FieldMethod,
+		metrics.FieldNamespace,
+		metrics.FieldService,
+		metrics.FieldStore,
+	)
+
+	sourceFieldKeys := []string{
+		metrics.FieldComponent,
+		metrics.FieldMethod,
+		metrics.FieldNamespace,
+		metrics.FieldSource,
+		metrics.FieldStore,
+	}
+
+	sourceErrCount, sourceOpCount, sourceOpLatency := metrics.KeyMetrics(
+		namespaceSource,
+		sourceFieldKeys...,
+	)
+
+	sourceQueueLatency := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespaceSource,
+			Subsystem: subsystemQueue,
+			Name:      "latency_seconds",
+			Help:      "Distribution of message queue latency in seconds",
+			Buckets:   metrics.BucketsQueue,
+		},
+		sourceFieldKeys,
+	)
+	prometheus.MustRegister(sourceQueueLatency)
+
+	// Setup clients.
+	var (
+		aSession = awsSession.New(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(*awsKey, *awsSecret, ""),
+			Region:      aws.String(*awsRegion),
+		})
+		snsAPI = sns.New(aSession)
+		sqsAPI = sqs.New(aSession)
+	)
+
+	pgClient, err := sqlx.Connect(storeService, *postgresURL)
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+		os.Exit(1)
+	}
+
+	// Setup services.
+	var apps app.Service
+	apps = app.PostgresService(pgClient)
+	apps = app.InstrumentServiceMiddleware(
+		component,
+		storeService,
+		serviceErrCount,
+		serviceOpCount,
+		serviceOpLatency,
+	)(apps)
+	apps = app.LogServiceMiddleware(logger, storeService)(apps)
+
+	var connections connection.Service
+	connections = connection.PostgresService(pgClient)
+	connections = connection.InstrumentServiceMiddleware(
+		component,
+		storeService,
+		serviceErrCount,
+		serviceOpCount,
+		serviceOpLatency,
+	)(connections)
+	connections = connection.LogServiceMiddleware(logger, storeService)(connections)
+
+	var devices device.Service
+	devices = device.PostgresService(pgClient)
+	devices = device.InstrumentServiceMiddleware(
+		component,
+		storeService,
+		serviceErrCount,
+		serviceOpCount,
+		serviceOpLatency,
+	)(devices)
+	devices = device.LogServiceMiddleware(logger, storeService)(devices)
+
+	var objects object.Service
+	objects = object.PostgresService(pgClient)
+	objects = object.InstrumentServiceMiddleware(
+		component,
+		storeService,
+		serviceErrCount,
+		serviceOpCount,
+		serviceOpLatency,
+	)(objects)
+	objects = object.LogServiceMiddleware(logger, storeService)(objects)
+
+	var users user.Service
+	users = user.PostgresService(pgClient)
+	users = user.InstrumentMiddleware(
+		component,
+		storeService,
+		serviceErrCount,
+		serviceOpCount,
+		serviceOpLatency,
+	)(users)
+	users = user.LogMiddleware(logger, storeService)(users)
+
+	// Setup sources.
+	conSource, err := connection.SQSSource(sqsAPI)
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+		os.Exit(1)
+	}
+	conSource = connection.InstrumentSourceMiddleware(
+		component,
+		source,
+		sourceErrCount,
+		sourceOpCount,
+		sourceOpLatency,
+		sourceQueueLatency,
+	)(conSource)
+	conSource = connection.LogSourceMiddleware(source, logger)(conSource)
+
+	eventSource, err := event.SQSSource(sqsAPI)
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+		os.Exit(1)
+	}
+	eventSource = event.InstrumentSourceMiddleware(
+		component,
+		source,
+		sourceErrCount,
+		sourceOpCount,
+		sourceOpLatency,
+		sourceQueueLatency,
+	)(eventSource)
+	eventSource = event.LogSourceMiddleware(source, logger)(eventSource)
+
+	objectSource, err := object.SQSSource(sqsAPI)
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+		os.Exit(1)
+	}
+	objectSource = object.InstrumentSourceMiddleware(
+		component,
+		source,
+		sourceErrCount,
+		sourceOpCount,
+		sourceOpLatency,
+		sourceQueueLatency,
+	)(objectSource)
+	objectSource = object.LogSourceMiddleware(source, logger)(objectSource)
+
+	logger.Log(
+		"duration", time.Now().Sub(begin).Nanoseconds(),
+		"lifecycle", "start",
+		"sub", "worker",
+	)
+
+	// React to SNS endpoint changes.
+	qName, err := queueName(sqsAPI, queueEndpointChanges)
+	if err != nil {
+		logger.Log("err", err, "lifecycle", "abort")
+		os.Exit(1)
+	}
+
+	changec := make(chan endpointChange)
+
+	go func() {
+		err := consumeEndpointChange(sqsAPI, qName, changec)
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort")
+			os.Exit(1)
+		}
+	}()
+
+	go func() {
+		for c := range changec {
+			a, err := appForARN(core.AppFetch(apps), pApps, c.Resource)
+			if err != nil {
+				if isPlatformNotFound(err) {
+					continue
+				}
+
+				logger.Log("err", err, "lifecycle", "abort")
+				os.Exit(1)
+			}
+
+			err = endpointUpdate(core.DeviceDisable(devices), a, c)
+			if err != nil {
+				logger.Log("err", err, "lifecycle", "abort")
+				os.Exit(1)
+			}
+		}
+	}()
+
+	// Consume entity state changes.
+	batchc := make(chan batch)
+
+	go func() {
+		err := consumeConnection(
+			core.AppFetch(apps),
+			conSource,
+			batchc,
+			conRuleFollower(
+				core.UserFetch(users),
+			),
+			conRuleFriendConfirmed(
+				core.UserFetch(users),
+			),
+			conRuleFriendRequest(
+				core.UserFetch(users),
+			),
+		)
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort")
+			os.Exit(1)
+		}
+	}()
+
+	go func() {
+		err := consumeEvent(
+			core.AppFetch(apps),
+			eventSource,
+			batchc,
+			eventRuleLikeCreated(
+				core.ConnectionFollowerIDs(connections),
+				core.ConnectionFriendIDs(connections),
+				core.PostFetch(objects),
+				core.UserFetch(users),
+				core.UsersFetch(users),
+			),
+		)
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort")
+			os.Exit(1)
+		}
+	}()
+
+	go func() {
+		err := consumeObject(
+			core.AppFetch(apps),
+			objectSource,
+			batchc,
+			objectRuleCommentCreated(
+				core.ConnectionFollowerIDs(connections),
+				core.ConnectionFriendIDs(connections),
+				core.PostFetch(objects),
+				core.UserFetch(users),
+				core.UsersFetch(users),
+			),
+			objectRulePostCreated(
+				core.ConnectionFollowerIDs(connections),
+				core.ConnectionFriendIDs(connections),
+				core.UserFetch(users),
+				core.UsersFetch(users),
+			),
+		)
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort")
+			os.Exit(1)
+		}
+	}()
+
+	// Distribute messages to channels.
+	cs := []channelFunc{
+		channelPush(
+			core.DeviceListUser(devices),
+			core.DeviceSyncEndpoint(
+				devices,
+				platformSNS.EndpointCreate(snsAPI),
+				platformSNS.EndpointRetrieve(snsAPI),
+				platformSNS.EndpointUpdate(snsAPI),
+			),
+			platformSNS.Push(snsAPI),
+			pApps,
+		),
+	}
+
+	for batch := range batchc {
+		for _, msg := range batch.messages {
+			for _, channel := range cs {
+				err := channel(batch.app, msg)
+				if err != nil {
+					logger.Log("err", err, "lifecycle", "abort")
+					os.Exit(1)
+				}
+			}
+		}
+
+		err = batch.ackFunc()
+		if err != nil {
+			logger.Log("err", err, "lifecycle", "abort")
+			os.Exit(1)
+		}
+	}
+
+	logger.Log("lifecycle", "stop")
+}
+
+func queueName(api platformSQS.API, name string) (string, error) {
+	res, err := api.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: aws.String(name),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *res.QueueUrl, nil
+}

--- a/core/app.go
+++ b/core/app.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"github.com/tapglue/snaas/service/app"
+)
+
+// AppFetchFunc returns the App for the given id.
+type AppFetchFunc func(id uint64) (*app.App, error)
+
+// AppFetchFunc returns the App for the given id.
+func AppFetch(apps app.Service) AppFetchFunc {
+	return func(id uint64) (*app.App, error) {
+		as, err := apps.Query(app.NamespaceDefault, app.QueryOptions{
+			Enabled: &defaultEnabled,
+			IDs: []uint64{
+				id,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(as) == 0 {
+			return nil, wrapError(ErrNotFound, "app (%d) not found", id)
+		}
+
+		return as[0], nil
+	}
+}

--- a/core/comment.go
+++ b/core/comment.go
@@ -306,6 +306,14 @@ func CommentUpdate(
 	}
 }
 
+func IsComment(o *object.Object) bool {
+	if o.Type != TypeComment {
+		return false
+	}
+
+	return o.Owned
+}
+
 func constrainCommentPrivate(origin Origin, private *object.Private) error {
 	if !origin.IsBackend() && private != nil {
 		return wrapError(ErrUnauthorized,

--- a/core/device.go
+++ b/core/device.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/tapglue/snaas/platform/sns"
 	"github.com/tapglue/snaas/service/app"
 	"github.com/tapglue/snaas/service/device"
 )
@@ -40,6 +41,125 @@ func DeviceDelete(devices device.Service) DeviceDeleteFunc {
 		_, err = devices.Put(currentApp.Namespace(), d)
 
 		return err
+	}
+}
+
+// DeviceDisableFunc disables the device for the given endpointARN.
+type DeviceDisableFunc func(currentApp *app.App, endpointARN string) error
+
+// DeviceDisable disables the device for the given endpointARN.
+func DeviceDisable(devices device.Service) DeviceDisableFunc {
+	return func(currentApp *app.App, endpointARN string) error {
+		ds, err := devices.Query(currentApp.Namespace(), device.QueryOptions{
+			Deleted: &defaultDeleted,
+			EndpointARNs: []string{
+				endpointARN,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(ds) == 0 {
+			return nil
+		}
+
+		d := ds[0]
+		d.Disabled = true
+
+		_, err = devices.Put(currentApp.Namespace(), d)
+
+		return err
+	}
+}
+
+// DeviceListUserFunc returns all devices for origin.
+type DeviceListUserFunc func(
+	currentApp *app.App,
+	origin uint64,
+) (device.List, error)
+
+// DeviceListUser returns all devices for origin.
+func DeviceListUser(devices device.Service) DeviceListUserFunc {
+	return func(currentApp *app.App, origin uint64) (device.List, error) {
+		return devices.Query(currentApp.Namespace(), device.QueryOptions{
+			Deleted:  &defaultDeleted,
+			Disabled: &defaultDeleted,
+			Platforms: []device.Platform{
+				device.PlatformIOSSandbox,
+				device.PlatformIOS,
+				device.PlatformAndroid,
+			},
+			UserIDs: []uint64{
+				origin,
+			},
+		})
+	}
+}
+
+// DeviceSyncEndpointFunc assures symmetry between the representation of the
+// Device in the device.Service and SNS.
+// * create endpoint if not present
+// * sync tokens if different
+type DeviceSyncEndpointFunc func(
+	currentApp *app.App,
+	platformARN string,
+	input *device.Device,
+) (*device.Device, error)
+
+// DeviceSyncEndpointFunc assures symmetry between the representation of the
+// Device in the device.Service and SNS Platform Application.
+// * create endpoint if not present
+// * sync tokens if different
+func DeviceSyncEndpoint(
+	devices device.Service,
+	endpointCreate sns.EndpointCreateFunc,
+	endpointRetrieve sns.EndpointRetrieveFunc,
+	endpointUpdate sns.EndpointUpdateFunc,
+) DeviceSyncEndpointFunc {
+	return func(
+		currentApp *app.App,
+		platformARN string,
+		input *device.Device,
+	) (*device.Device, error) {
+		// Create a new Endpoint for the device if none was created before.
+		if input.EndpointARN == "" {
+			e, err := endpointCreate(platformARN, input.Token)
+			if err != nil {
+				return nil, err
+			}
+
+			input.EndpointARN = e.ARN
+
+			return devices.Put(currentApp.Namespace(), input)
+		}
+
+		e, err := endpointRetrieve(input.EndpointARN)
+		if err != nil && !sns.IsEndpointNotFound(err) {
+			return nil, err
+		}
+
+		// If the Endpoint is gone we create a new one.
+		if sns.IsEndpointNotFound(err) {
+			e, err := endpointCreate(platformARN, input.Token)
+			if err != nil {
+				return nil, err
+			}
+
+			input.EndpointARN = e.ARN
+
+			return devices.Put(currentApp.Namespace(), input)
+		}
+
+		// Check if Tokens match.
+		if input.Token != e.Token {
+			_, err := endpointUpdate(input.EndpointARN, input.Token)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return input, nil
 	}
 }
 

--- a/core/like.go
+++ b/core/like.go
@@ -297,7 +297,7 @@ func LikesUser(
 			ls = ls[:opts.Limit]
 		}
 
-		ps = postsByEvents(ls, ps.toMap())
+		ps = postsForLikes(ls, ps.toMap())
 
 		err = enrichCounts(events, objects, currentApp, ps)
 		if err != nil {
@@ -327,6 +327,15 @@ func LikesUser(
 			UserMap: um,
 		}, nil
 	}
+}
+
+// IsLike indicates if Event is a Like.
+func IsLike(e *event.Event) bool {
+	if e.Type != TypeLike {
+		return false
+	}
+
+	return e.Owned
 }
 
 func constrainLikeRestriction(restrictions *object.Restrictions) error {
@@ -364,7 +373,7 @@ func eventVisibilitiesForRelation(r *relation) []event.Visibility {
 	}
 }
 
-func postsByEvents(es event.List, pm PostMap) PostList {
+func postsForLikes(es event.List, pm PostMap) PostList {
 	ps := PostList{}
 
 	for _, event := range es {

--- a/core/user.go
+++ b/core/user.go
@@ -90,6 +90,30 @@ func UserDelete(
 	}
 }
 
+// UserFetchFunc returns the User for the given id.
+type UserFetchFunc func(currentApp *app.App, id uint64) (*user.User, error)
+
+// UserFetch returns the User for the given id.
+func UserFetch(users user.Service) UserFetchFunc {
+	return func(currentApp *app.App, id uint64) (*user.User, error) {
+		us, err := users.Query(currentApp.Namespace(), user.QueryOptions{
+			Enabled: &defaultEnabled,
+			IDs: []uint64{
+				id,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(us) == 0 {
+			return nil, ErrNotFound
+		}
+
+		return us[0], nil
+	}
+}
+
 // UserListByEmailsFunc returns all users for the given emails.
 type UserListByEmailsFunc func(
 	currentApp *app.App,
@@ -446,6 +470,22 @@ func UserUpdate(
 		}
 
 		return u, nil
+	}
+}
+
+// UsersFetchFunc retrieves the users for the given ids.
+type UsersFetchFunc func(currentApp *app.App, ids ...uint64) (user.List, error)
+
+func UsersFetch(users user.Service) UsersFetchFunc {
+	return func(currentApp *app.App, ids ...uint64) (user.List, error) {
+		if len(ids) == 0 {
+			return user.List{}, nil
+		}
+
+		return users.Query(currentApp.Namespace(), user.QueryOptions{
+			Enabled: &defaultEnabled,
+			IDs:     ids,
+		})
 	}
 }
 

--- a/platform/sns/error.go
+++ b/platform/sns/error.go
@@ -1,0 +1,60 @@
+package sns
+
+import (
+	"errors"
+	"fmt"
+)
+
+const errFmt = "%s: %s"
+
+// Common errors for Device serive implementations and validations.
+var (
+	ErrDeliveryFailure  = errors.New("delivery failed")
+	ErrEndpointDisabled = errors.New("endppint disabled")
+	ErrEndpointNotFound = errors.New("endpoint not found")
+)
+
+// Error wraps common Device errors.
+type Error struct {
+	err error
+	msg string
+}
+
+func (e Error) Error() string {
+	return e.msg
+}
+
+// IsDeliveryFailure indicates if err is ErrDeliveryFailure
+func IsDeliveryFailure(err error) bool {
+	return unwrapError(err) == ErrDeliveryFailure
+}
+
+// IsEndpointDisabled indicates if err is ErrEndpointDisabled.
+func IsEndpointDisabled(err error) bool {
+	return unwrapError(err) == ErrEndpointDisabled
+}
+
+// IsEndpointNotFound indicates if err is ErrEndpointNotFound.
+func IsEndpointNotFound(err error) bool {
+	return unwrapError(err) == ErrEndpointNotFound
+}
+
+func unwrapError(err error) error {
+	switch e := err.(type) {
+	case *Error:
+		return e.err
+	}
+
+	return err
+}
+
+func wrapError(err error, format string, args ...interface{}) error {
+	return &Error{
+		err: err,
+		msg: fmt.Sprintf(
+			errFmt,
+			err,
+			fmt.Sprintf(format, args...),
+		),
+	}
+}

--- a/platform/sns/sns.go
+++ b/platform/sns/sns.go
@@ -1,0 +1,177 @@
+package sns
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sns"
+)
+
+// Message Attributes.
+const (
+	AttributeEnabled = "Enabled"
+	AttributeToken   = "Token"
+)
+
+// Message Types.
+const (
+	TypeDeliveryFailure = "DeliveryFailure"
+	TypeNotification    = "Notification"
+)
+
+// Platform supported by SNS for push.
+const (
+	PlatformADM Platform = iota + 1
+	PlatformAPNS
+	PlatformAPNSSandbox
+	PlatformGCM
+)
+
+// Publish structures.
+const (
+	structureJSON = "json"
+)
+
+// Push formats.
+const (
+	fmtURN         = `%s://%s`
+	msgAPNS        = `{"APNS": "{\"aps\": {\"alert\": \"%s\"}, \"urn\":\"%s\"}" }`
+	msgAPNSSandbox = `{"APNS_SANDBOX": "{\"aps\": {\"alert\": \"%s\"}, \"urn\":\"%s\"}" }`
+	msgGCM         = `{"GCM": "{\"notification\": {\"title\": \"%s\", \"data\": {\"urn\": \"%s\"}} }"}`
+)
+
+type API interface {
+	CreatePlatformEndpoint(*sns.CreatePlatformEndpointInput) (*sns.CreatePlatformEndpointOutput, error)
+	GetEndpointAttributes(*sns.GetEndpointAttributesInput) (*sns.GetEndpointAttributesOutput, error)
+	SetEndpointAttributes(*sns.SetEndpointAttributesInput) (*sns.SetEndpointAttributesOutput, error)
+	Publish(*sns.PublishInput) (*sns.PublishOutput, error)
+}
+
+// Endpoint is the AWS SNS representation of a Device.
+type Endpoint struct {
+	ARN   string
+	Token string
+}
+
+// Platform of a device.
+type Platform uint8
+
+// EndpointCreateFunc registers a new device endpoint for the given platform
+// and token.
+type EndpointCreateFunc func(platformARN, token string) (*Endpoint, error)
+
+// EndpointCreate registers a new device endpoint for the given platform and
+// token.
+func EndpointCreate(api API) EndpointCreateFunc {
+	return func(platformARN, token string) (*Endpoint, error) {
+		r, err := api.CreatePlatformEndpoint(&sns.CreatePlatformEndpointInput{
+			PlatformApplicationArn: aws.String(platformARN),
+			Token: aws.String(token),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &Endpoint{
+			ARN:   *r.EndpointArn,
+			Token: token,
+		}, nil
+	}
+}
+
+// EndpointRetrieveFunc returns the Endpoint for the given ARN.
+type EndpointRetrieveFunc func(arn string) (*Endpoint, error)
+
+// EndpointRetrieve returns the Endpoint for the given ARN.
+func EndpointRetrieve(api API) EndpointRetrieveFunc {
+	return func(arn string) (*Endpoint, error) {
+		r, err := api.GetEndpointAttributes(
+			&sns.GetEndpointAttributesInput{
+				EndpointArn: aws.String(arn),
+			},
+		)
+		if err != nil {
+			if awsErr, ok := err.(awserr.RequestFailure); ok &&
+				awsErr.StatusCode() == 404 {
+				return nil, ErrEndpointNotFound
+			}
+
+			return nil, err
+		}
+
+		if *r.Attributes[AttributeEnabled] == "false" {
+			return nil, ErrEndpointDisabled
+		}
+
+		return &Endpoint{
+			ARN:   arn,
+			Token: *r.Attributes[AttributeToken],
+		}, nil
+	}
+}
+
+// EndpointUpdateFunc takes a new token and stores it with the Endpoint.
+type EndpointUpdateFunc func(arn, token string) (*Endpoint, error)
+
+// EndpointUpdate takes a new token and stores it with the Endpoint.
+func EndpointUpdate(api API) EndpointUpdateFunc {
+	return func(arn, token string) (*Endpoint, error) {
+		_, err := api.SetEndpointAttributes(&sns.SetEndpointAttributesInput{
+			Attributes: map[string]*string{
+				AttributeToken: aws.String(token),
+			},
+			EndpointArn: aws.String(arn),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &Endpoint{
+			ARN:   arn,
+			Token: token,
+		}, nil
+	}
+}
+
+// PushAFunc pushes a new notification to the device for the given endpoint ARN.
+type PushFunc func(
+	platform Platform,
+	endpointARN, scheme, urn, message string,
+) error
+
+// Push pushes a new notification to the device for the given endpoint ARN.
+func Push(api API) PushFunc {
+	return func(p Platform, arn, scheme, urn, message string) error {
+		fmtMsg := ""
+
+		switch p {
+		case PlatformAPNS:
+			fmtMsg = msgAPNS
+		case PlatformAPNSSandbox:
+			fmtMsg = msgAPNSSandbox
+		case PlatformGCM:
+			fmtMsg = msgGCM
+		}
+
+		var (
+			u = fmt.Sprintf(fmtURN, scheme, urn)
+			m = fmt.Sprintf(fmtMsg, message, u)
+		)
+
+		_, err := api.Publish(&sns.PublishInput{
+			Message:          aws.String(m),
+			MessageStructure: aws.String(structureJSON),
+			TargetArn:        aws.String(arn),
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.RequestFailure); ok {
+				if awsErr.StatusCode() == 400 {
+					return ErrDeliveryFailure
+				}
+			}
+		}
+
+		return nil
+	}
+}

--- a/platform/source/source.go
+++ b/platform/source/source.go
@@ -1,0 +1,6 @@
+package source
+
+// Acker permantly removes the workload from the Source.
+type Acker interface {
+	Ack(id string) error
+}

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -11,7 +11,7 @@ const (
 	// NamespaceDefault is the default namespace to isolate top-level data sets.
 	NamespaceDefault = "tg"
 
-	fmtNamespace = "app_%d_%d"
+	fmtNamespace = "app_%d"
 
 	limitProduction = 20000
 	limitStaging    = 100
@@ -25,9 +25,6 @@ type App struct {
 	ID           uint64    `json:"-"`
 	InProduction bool      `json:"in_production"`
 	Name         string    `json:"name"`
-	OrgID        uint64    `json:"-"`
-	PublicID     string    `json:"id"`
-	PublicOrgID  string    `json:"account_id"`
 	Token        string    `json:"token"`
 	URL          string    `json:"url"`
 	CreatedAt    time.Time `json:"created_at"`
@@ -44,10 +41,9 @@ func (a *App) Limit() int64 {
 	return limitStaging
 }
 
-// Namespace is the identifier used to slice and dice data related to a
-// customers app.
+// Namespace is the identifier used to slice and dice data related to a an app.
 func (a *App) Namespace() string {
-	return fmt.Sprintf(fmtNamespace, a.OrgID, a.ID)
+	return fmt.Sprintf(fmtNamespace, a.ID)
 }
 
 func (a *App) Validate() error {
@@ -65,8 +61,6 @@ type QueryOptions struct {
 	IDs           []uint64
 	InProduction  *bool
 	Limit         int
-	OrgIDs        []uint64
-	PublicIDs     []string
 	Tokens        []string
 }
 

--- a/service/app/helper_test.go
+++ b/service/app/helper_test.go
@@ -18,9 +18,6 @@ func testApp() *App {
 		InProduction: false,
 		Enabled:      true,
 		Name:         generate.RandomString(8),
-		OrgID:        1,
-		PublicID:     generate.RandomString(16),
-		PublicOrgID:  generate.RandomString(16),
 		Token:        generate.RandomString(8),
 	}
 }
@@ -34,7 +31,6 @@ func testList() List {
 
 	for i := 0; i < 5; i++ {
 		a := testApp()
-		a.OrgID = 2
 
 		as = append(as, a)
 	}
@@ -127,11 +123,9 @@ func testServiceQuery(t *testing.T, p prepareFunc) {
 	}
 
 	cases := map[*QueryOptions]int{
-		&QueryOptions{}:                                              15,
-		&QueryOptions{OrgIDs: []uint64{2}}:                           5,
+		&QueryOptions{}: 15,
 		&QueryOptions{BackendTokens: []string{created.BackendToken}}: 1,
 		&QueryOptions{IDs: []uint64{created.ID}}:                     1,
-		&QueryOptions{PublicIDs: []string{created.PublicID}}:         1,
 		&QueryOptions{Tokens: []string{created.Token}}:               1,
 	}
 

--- a/service/connection/connection.go
+++ b/service/connection/connection.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/tapglue/snaas/platform/service"
+	"github.com/tapglue/snaas/platform/source"
 )
 
 // Supported states for connections.
@@ -18,11 +19,6 @@ const (
 	TypeFollow Type = "follow"
 	TypeFriend Type = "friend"
 )
-
-// Acker permantly removes the workload from the Source.
-type Acker interface {
-	Ack(id string) error
-}
 
 // Connection represents a relation between two users.
 type Connection struct {
@@ -149,7 +145,7 @@ type StateChange struct {
 
 // Source encapsulates state change notification operations.
 type Source interface {
-	Acker
+	source.Acker
 	Consumer
 	Producer
 }

--- a/service/event/event.go
+++ b/service/event/event.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tapglue/snaas/platform/service"
+	"github.com/tapglue/snaas/platform/source"
 )
 
 // Predefined time periods to use for aggregates.
@@ -29,11 +30,6 @@ const (
 	TypeFollow = "tg_follow"
 	TypeFriend = "tg_friend"
 )
-
-// Acker permantly removes the workload from the Source.
-type Acker interface {
-	Ack(id string) error
-}
 
 // Consumer observes state changes.
 type Consumer interface {
@@ -188,7 +184,7 @@ type StateChange struct {
 
 // Source encapsulates state change notifications operations.
 type Source interface {
-	Acker
+	source.Acker
 	Consumer
 	Producer
 }

--- a/service/object/object.go
+++ b/service/object/object.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/asaskevich/govalidator"
 	"golang.org/x/text/language"
 
-	"github.com/asaskevich/govalidator"
-
 	"github.com/tapglue/snaas/platform/service"
+	"github.com/tapglue/snaas/platform/source"
 )
 
 // Attachment variants available for Objects.
@@ -34,11 +34,6 @@ const (
 	VisibilityPublic
 	VisibilityGlobal
 )
-
-// Acker permantly removes the workload from the Source.
-type Acker interface {
-	Ack(id string) error
-}
 
 // Attachment is typed media which belongs to an Object.
 type Attachment struct {
@@ -260,7 +255,7 @@ type StateChange struct {
 
 // Source encapsulates state change notification operations.
 type Source interface {
-	Acker
+	source.Acker
 	Consumer
 	Producer
 }


### PR DESCRIPTION
Wherein we implement a new worker binary called SIMS (Signal informed Messaging Service) which consumes the state changes emitted by the API and by applying rules determines who to send transactional messages to. In this first iteration we only target mobile platforms with push messages. As the delivery platform SNS is supported and used for the bookkeeping of endpoint per device.

* implment SIMS binary
* add rules for:
  - new follower
  - new friend request
  - friend request confirmed
  - new like
  - new comment
  - new post
* introduce SNS as push delivery platform