### PR TITLE
Simplify infrastructure

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,19 @@
+infrastructure:
+ ✔ finish terraform PR @done (16-11-09 12:19) https://github.com/tapglue/snaas/pull/5
+ ✔ monitoring ami and key @done (16-11-09 18:43)
+ ✔ bastion ami and key @done (16-11-09 18:43)
+ ✔ fix new resource force on ec2 instances @done (16-11-09 21:42)
+ ☐ require ssh key during setup
+ ☐ generate pg password during setup
+ ☐ docker foundation
+ ☐ setup circle integration
+ ☐ gateway-http Dockerfile
+ ☐ sims Dockerfile
+ ☐ publish docker artifacts to DockerHub
+ ☐ setup prometheus and grafana
+ ☐ fix pg monitoring role
+ ☐ setup grafana and prometheus on monitoring host
+
+code:
+ ☐ move event condition code
+ ☐ add missing event indeces

--- a/cmd/terraformer/terraformer.go
+++ b/cmd/terraformer/terraformer.go
@@ -185,7 +185,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		fmt.Println("Want to apply the plan? (type 'yes')")
+		fmt.Println("\nWant to apply the plan? (type 'yes')")
 		fmt.Print("(no) |> ")
 
 		response := "no"

--- a/infrastructure/terraform/template/network.tf
+++ b/infrastructure/terraform/template/network.tf
@@ -121,12 +121,13 @@ resource "aws_route_table_association" "platform-b" {
 }
 
 resource "aws_instance" "bastion" {
-  ami             = "${var.ami["bastion"]}"
-  instance_type   = "t2.medium"
-  security_groups = [
+  ami                     = "${var.ami_minimal["${var.region}"]}"
+  instance_type           = "t2.medium"
+  key_name                = "${aws_key_pair.access.key_name}"
+  vpc_security_group_ids  = [
     "${aws_security_group.perimeter.id}",
   ]
-  subnet_id       = "${aws_subnet.perimeter-a.id}"
+  subnet_id               = "${aws_subnet.perimeter-a.id}"
 
   tags {
     Name = "bastion"

--- a/infrastructure/terraform/template/platform.tf
+++ b/infrastructure/terraform/template/platform.tf
@@ -1,7 +1,8 @@
 resource "aws_instance" "monitoring" {
-  ami             = "${var.ami["monitoring"]}"
+  ami             = "${var.ami_minimal["${var.region}"]}"
   instance_type   = "t2.medium"
-  security_groups = [
+  key_name        = "${aws_key_pair.access.key_name}"
+  vpc_security_group_ids = [
     "${aws_security_group.platform.id}",
   ]
   subnet_id       = "${aws_subnet.platform-a.id}"
@@ -85,9 +86,9 @@ resource "aws_launch_configuration" "service" {
   associate_public_ip_address = false
   ebs_optimized               = false
   enable_monitoring           = true
-  key_name                    = "${aws_key_pair.debug.key_name}"
+  key_name                    = "${aws_key_pair.access.key_name}"
   iam_instance_profile        = "${aws_iam_instance_profile.ecs-agent-profile.name}"
-  image_id                    = "${var.ami["ecs-agent"]}"
+  image_id                    = "${var.ami_ecs_agent["${var.region}"]}"
   instance_type               =  "m4.large"
   name_prefix                 = "ecs-service-"
   security_groups             = [

--- a/infrastructure/terraform/template/storage.tf
+++ b/infrastructure/terraform/template/storage.tf
@@ -85,7 +85,7 @@ resource "aws_db_parameter_group" "service-master" {
   }
 
   parameter {
-    apply_method = "immediate"
+    apply_method = "pending-reboot"
     name         = "max_connections"
     value        = "256"
   }
@@ -117,8 +117,8 @@ resource "aws_db_instance" "service-master" {
   engine_version            = "9.5.4"
   instance_class            = "db.r3.xlarge"
   maintenance_window        = "sat:05:00-sat:06:30"
-  monitoring_interval       = 1
-  monitoring_role_arn       = "${aws_iam_role.rds-monitoring.arn}"
+  # monitoring_interval       = 1
+  # monitoring_role_arn       = "${aws_iam_role.rds-monitoring.arn}"
   multi_az                  = true
   parameter_group_name      = "${aws_db_parameter_group.service-master.id}"
   publicly_accessible       = false

--- a/infrastructure/terraform/template/variables.tf
+++ b/infrastructure/terraform/template/variables.tf
@@ -4,9 +4,29 @@ variable "account" {
   type        = "string"
 }
 
-variable "ami" {
-  default     = {}
-  description = "AMIs used for components"
+variable "ami_ecs_agent" {
+  default = {
+    "us-east-1"     = "ami-1924770e"
+    "us-east-2"     = "ami-bd3e64d8"
+    "us-west-1"     = "ami-7f004b1f"
+    "us-west-2"     = "ami-56ed4936"
+    "eu-west-1"     = "ami-c8337dbb"
+    "eu-central-1"  = "ami-dd12ebb2"
+  }
+  description = "AMIs used for ecs agent"
+  type        = "map"
+}
+
+variable "ami_minimal" {
+  default = {
+    "us-east-1"     = "ami-6d1c2007"
+    "us-east-2"     = "ami-6a2d760f"
+    "us-west-1"     = "ami-af4333cf"
+    "us-west-2"     = "ami-d2c924b2"
+    "eu-west-1"     = "ami-7abd0209"
+    "eu-central-1"  = "ami-9bf712f4"
+  }
+  description = "AMIs used for auxiliary hosts"
   type        = "map"
 }
 
@@ -14,6 +34,14 @@ variable "env" {
   default     = ""
   description = "environment name used for isolation"
   type        = "string"
+}
+
+variable "key" {
+  default = {
+    "access" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCuFsJxH52k7iI4mseWljlbQhwIfbpVPuDCTOBo6YtI7xL3f3jfme4fqziwt+iqavRW2MgGsgoYGITNYstZa5zzT4Zo6CTZ0XpeLYZrrXQOxXrXjesRA478bCsU4gpCrPiy5Uzw3e2d1HLF/deLjnmREshzqaEQKoL8tzG51esBTIna+M5aWD0AGPFotO3J2sFTRnbAIxeVj4bKWAfaE2+WG1MX1VemDGeGrHmW6UbPoymHOD7Y5c/F00Bv+Pgk5LwCyRCvEzMLbl2GHpEJd3vcouwEToyADlN1rXc+85SfVtlwS8F3fX6vqjQ/2fMzG4syaDEeUJLsBcE2glNIwDH/ debug"
+  }
+  description = "SSH public keys"
+  type        = "map"
 }
 
 variable "region" {
@@ -41,7 +69,10 @@ variable "pg_password" {
 }
 
 variable "version" {
-  default     = {}
+  default     = {
+    "gateway-http" = "1"
+    "sims" = "1"
+  }
   description = "Versions used for deployed services"
   type        = "map"
 }


### PR DESCRIPTION
Wherein we try to simplify the infrastructure to the point where we don't need custom AMIs and extensive tooling to create Docker containers. We achieve the first one by using of-the-shelf AMIs offered in marketplaces and/or advertised by AWS. The second one is solved with using a public repository[0] on DockerHub.

* use pre-maded images
* use configured SSH key
* introduce simple TODO list