### PR TITLE
Enable Docker build pipeline

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,16 +4,16 @@ infrastructure:
  ✔ bastion ami and key @done (16-11-09 18:43)
  ✔ fix new resource force on ec2 instances @done (16-11-09 21:42)
  ✔ setup circle integration @done (16-11-10 19:50)
+ ✔ docker foundation @done (16-11-10 22:14)
+ ✔ gateway-http Dockerfile @done (16-11-10 22:14)
+ ✔ sims Dockerfile @done (16-11-10 22:14)
+ ✔ publish docker artifacts to DockerHub @done (16-11-10 22:14)
  ☐ require ssh key during setup
  ☐ generate pg password during setup
- ☐ docker foundation
- ☐ gateway-http Dockerfile
- ☐ sims Dockerfile
- ☐ publish docker artifacts to DockerHub
- ☐ setup prometheus and grafana
  ☐ fix pg monitoring role
  ☐ setup grafana and prometheus on monitoring host
 
 code:
  ☐ move event condition code
  ☐ add missing event indeces
+ ☐ enable TLS and load certs

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,4 @@
 machine:
-  pre:
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
-    - sudo chmod 0755 /usr/bin/docker
   environment:
     GOOROT: /home/ubuntu/.gimme/versions/go1.7.linux.amd64
   services:
@@ -22,3 +19,10 @@ database:
 test:
   override:
     - ./infrastructure/scripts/execute-tests
+deployment:
+  docker:
+    branch: master
+    commands:
+      - ./infrastructure/scripts/build-container
+      - docker login -e ${DOCKERHUB_EMAIL} -p ${DOCKERHUB_PASSWORD} -u ${DOCKERHUB_USERNAME}
+      - docker push tapglue/snaas

--- a/infrastructure/docker/snaas.docker
+++ b/infrastructure/docker/snaas.docker
@@ -1,0 +1,15 @@
+FROM alpine:3.4
+MAINTAINER Tapglue "docker@tapglue.com"
+
+ARG GATEWAY_HTTP_BINARY
+ARG SIMS_BINARY
+
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+RUN apk add --update ca-certificates && rm -rf /var/cache/apk/*
+
+ADD infrastructure/certs/self/self.crt /tapglue/self.crt
+ADD infrastructure/certs/self/self.key /tapglue/self.key
+
+ADD $GATEWAY_HTTP_BINARY /tapglue/gateway-http
+ADD $SIMS /tapglue/sims

--- a/infrastructure/scripts/build-container
+++ b/infrastructure/scripts/build-container
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+echo "|> prepare env"
+export CWD=$(pwd)
+export REVISION=$(git rev-parse --short HEAD)
+source ~/.gimme/envs/gotip.env
+cd /home/ubuntu/.go_workspace/src/github.com/tapglue/snaas
+
+echo "|> build gateway-http"
+go build \
+	-ldflags "-X main.revision=${REVISION}" \
+	-o gateway-http_${CIRCLE_BUILD_NUM} \
+	cmd/gateway-http/*.go
+
+echo "|> build sims"
+go build \
+	-ldflags "-X main.revision=${REVISION}" \
+	-o sims_${CIRCLE_BUILD_NUM} \
+	cmd/sims/*.go
+
+echo "|> build container"
+docker build \
+	-f ${CWD}/infrastructure/docker/snaas.docker \
+    -t tapglue/snaas:${CIRCLE_BUILD_NUM} \
+    --build-arg GATEWAY_HTTP_BINARY=gateway-http_${CIRCLE_BUILD_NUM} \
+    --build-arg SIMS_BINARY=sims_${CIRCLE_BUILD_NUM} \
+    ${CWD}


### PR DESCRIPTION
In order to distribute our core software we introduce centralised, public images on DockerHub which are fed by artifacts created in the CI build pipeline.