### PR TITLE
Reactions

### DIFF
--- a/core/feed.go
+++ b/core/feed.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tapglue/snaas/service/connection"
 	"github.com/tapglue/snaas/service/event"
 	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/reaction"
 	"github.com/tapglue/snaas/service/user"
 )
 
@@ -199,6 +200,7 @@ func FeedEvents(
 	connections connection.Service,
 	events event.Service,
 	objects object.Service,
+	reactions reaction.Service,
 	users user.Service,
 ) FeedEventsFunc {
 	return func(
@@ -254,7 +256,7 @@ func FeedEvents(
 			return nil, err
 		}
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}
@@ -318,6 +320,7 @@ func FeedNews(
 	connections connection.Service,
 	events event.Service,
 	objects object.Service,
+	reactions reaction.Service,
 	users user.Service,
 ) FeedNewsFunc {
 	return func(
@@ -374,7 +377,7 @@ func FeedNews(
 			return nil, err
 		}
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}
@@ -431,7 +434,7 @@ func FeedNews(
 			return nil, err
 		}
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}
@@ -471,6 +474,7 @@ func FeedNotificationsSelf(
 	connections connection.Service,
 	events event.Service,
 	objects object.Service,
+	reactions reaction.Service,
 	users user.Service,
 ) FeedNotificationsSelfFunc {
 	return func(
@@ -519,7 +523,7 @@ func FeedNotificationsSelf(
 			return nil, err
 		}
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}
@@ -552,6 +556,7 @@ func FeedPosts(
 	connections connection.Service,
 	events event.Service,
 	objects object.Service,
+	reactions reaction.Service,
 	users user.Service,
 ) FeedPostsFunc {
 	return func(
@@ -599,7 +604,7 @@ func FeedPosts(
 			return nil, err
 		}
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}

--- a/core/like.go
+++ b/core/like.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tapglue/snaas/service/connection"
 	"github.com/tapglue/snaas/service/event"
 	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/reaction"
 	"github.com/tapglue/snaas/service/user"
 )
 
@@ -24,7 +25,7 @@ type LikeFeed struct {
 	UserMap user.Map
 }
 
-// LikeCreate checks if a like for the owner on the post exists and if not
+// LikeCreateFunc checks if a like for the owner on the post exists and if not
 // creates a new event for it.
 type LikeCreateFunc func(
 	currentApp *app.App,
@@ -32,7 +33,7 @@ type LikeCreateFunc func(
 	postID uint64,
 ) (*event.Event, error)
 
-// Create checks if a like for the owner on the post exists and if not creates
+// LikeCreate checks if a like for the owner on the post exists and if not creates
 // a new event for it.
 func LikeCreate(
 	connections connection.Service,
@@ -268,6 +269,7 @@ func LikesUser(
 	connections connection.Service,
 	events event.Service,
 	objects object.Service,
+	reactions reaction.Service,
 	users user.Service,
 ) LikesUserFunc {
 	return func(
@@ -306,7 +308,7 @@ func LikesUser(
 
 		ps = postsForLikes(ls, ps.toMap())
 
-		err = enrichCounts(events, objects, currentApp, ps)
+		err = enrichCounts(events, objects, reactions, currentApp, ps)
 		if err != nil {
 			return nil, err
 		}

--- a/core/post_test.go
+++ b/core/post_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tapglue/snaas/service/connection"
 	"github.com/tapglue/snaas/service/event"
 	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/reaction"
 	"github.com/tapglue/snaas/service/user"
 )
 
@@ -138,8 +139,9 @@ func TestPostListAll(t *testing.T) {
 		connections = connection.MemService()
 		events      = event.MemService()
 		objects     = object.MemService()
+		reactions   = reaction.MemService()
 		users       = user.MemService()
-		fn          = PostListAll(connections, events, objects, users)
+		fn          = PostListAll(connections, events, objects, reactions, users)
 	)
 
 	feed, err := fn(app, owner.ID, object.QueryOptions{})
@@ -174,8 +176,9 @@ func TestPostListUser(t *testing.T) {
 		connections = connection.MemService()
 		events      = event.MemService()
 		objects     = object.MemService()
+		reactions   = reaction.MemService()
 		users       = user.MemService()
-		fn          = PostListUser(connections, events, objects, users)
+		fn          = PostListUser(connections, events, objects, reactions, users)
 	)
 
 	feed, err := fn(app, owner.ID, owner.ID, object.QueryOptions{})
@@ -210,8 +213,9 @@ func TestPostRetrieve(t *testing.T) {
 		connections = connection.MemService()
 		events      = event.MemService()
 		objects     = object.MemService()
+		reactions   = reaction.MemService()
 		post        = testPost(owner.ID)
-		fn          = PostRetrieve(connections, events, objects)
+		fn          = PostRetrieve(connections, events, objects, reactions)
 	)
 
 	created, err := objects.Put(app.Namespace(), post.Object)

--- a/core/reaction.go
+++ b/core/reaction.go
@@ -1,0 +1,224 @@
+package core
+
+import (
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/connection"
+	"github.com/tapglue/snaas/service/event"
+	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/reaction"
+	"github.com/tapglue/snaas/service/user"
+)
+
+// ReactionCreateFunc checks if a Reaction of the given type already exists on
+// the post for the origin.
+type ReactionCreateFunc func(
+	currentApp *app.App,
+	origin uint64,
+	postID uint64,
+	reactionType reaction.Type,
+) (*reaction.Reaction, error)
+
+// ReactionCreate checks if a Reaction of the given type already exists on the
+// post for the origin.
+func ReactionCreate(
+	connections connection.Service,
+	objects object.Service,
+	reactions reaction.Service,
+) ReactionCreateFunc {
+	return func(
+		currentApp *app.App,
+		origin uint64,
+		postID uint64,
+		reactionType reaction.Type,
+	) (*reaction.Reaction, error) {
+		p, err := PostFetch(objects)(currentApp, postID)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := constrainLikeRestriction(p.Restrictions); err != nil {
+			return nil, err
+		}
+
+		if err := isPostVisible(connections, currentApp, p.Object, origin); err != nil {
+			return nil, err
+		}
+
+		rs, err := reactions.Query(currentApp.Namespace(), reaction.QueryOptions{
+			ObjectIDs: []uint64{
+				postID,
+			},
+			OwnerIDs: []uint64{
+				origin,
+			},
+			Types: []reaction.Type{
+				reactionType,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(rs) == 1 && rs[0].Deleted == false {
+			return rs[0], nil
+		}
+
+		var r *reaction.Reaction
+
+		if len(rs) == 1 {
+			r = rs[0]
+			r.Deleted = false
+		} else {
+			r = &reaction.Reaction{
+				Deleted:  false,
+				ObjectID: postID,
+				OwnerID:  origin,
+				Type:     reactionType,
+			}
+		}
+
+		return reactions.Put(currentApp.Namespace(), r)
+	}
+}
+
+// ReactionDeleteFunc remvoes an existing Reaction from the Post.
+type ReactionDeleteFunc func(
+	currentApp *app.App,
+	origin, postID uint64,
+	reactionType reaction.Type,
+) error
+
+// ReactionDelete remvoes an existing Reaction from the Post.
+func ReactionDelete(
+	connections connection.Service,
+	objects object.Service,
+	reactions reaction.Service,
+) ReactionDeleteFunc {
+	return func(
+		currentApp *app.App,
+		origin, postID uint64,
+		reactionType reaction.Type,
+	) error {
+		p, err := PostFetch(objects)(currentApp, postID)
+		if err != nil {
+			return err
+		}
+
+		if err := isPostVisible(connections, currentApp, p.Object, origin); err != nil {
+			return err
+		}
+
+		rs, err := reactions.Query(currentApp.Namespace(), reaction.QueryOptions{
+			Deleted: &defaultDeleted,
+			ObjectIDs: []uint64{
+				postID,
+			},
+			OwnerIDs: []uint64{
+				origin,
+			},
+			Types: []reaction.Type{
+				reactionType,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(rs) == 0 {
+			return nil
+		}
+
+		reaction := rs[0]
+		reaction.Deleted = true
+
+		_, err = reactions.Put(currentApp.Namespace(), reaction)
+
+		return err
+	}
+}
+
+// ReactionListPostFunc returns all reactions for a Post.
+type ReactionListPostFunc func(
+	currentApp *app.App,
+	origin, postID uint64,
+	opts reaction.QueryOptions,
+) (*ReactionFeed, error)
+
+// ReactionListPost returns all reactions for a Post.
+func ReactionListPost(
+	connections connection.Service,
+	events event.Service,
+	objects object.Service,
+	reactions reaction.Service,
+	users user.Service,
+) ReactionListPostFunc {
+	return func(
+		currentApp *app.App,
+		origin, postID uint64,
+		opts reaction.QueryOptions,
+	) (*ReactionFeed, error) {
+		p, err := PostFetch(objects)(currentApp, postID)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := isPostVisible(connections, currentApp, p.Object, origin); err != nil {
+			return nil, err
+		}
+
+		rs, err := reactions.Query(currentApp.Namespace(), reaction.QueryOptions{
+			Before:  opts.Before,
+			Deleted: &defaultDeleted,
+			Limit:   opts.Limit,
+			ObjectIDs: []uint64{
+				postID,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		um, err := user.MapFromIDs(users, currentApp.Namespace(), append(rs.OwnerIDs(), p.OwnerID)...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, u := range um {
+			err := enrichRelation(connections, currentApp, origin, u)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = enrichCounts(events, objects, reactions, currentApp, PostList{p})
+		if err != nil {
+			return nil, err
+		}
+
+		return &ReactionFeed{
+			PostMap: PostMap{
+				p.ID: p,
+			},
+			Reactions: rs,
+			UserMap:   um,
+		}, nil
+	}
+}
+
+// ReactionFeed is a collection of Reactions with their referenced Users and
+// Posts.
+type ReactionFeed struct {
+	Reactions reaction.List
+	PostMap   PostMap
+	UserMap   user.Map
+}
+
+// ReactionCounts bundles all Reaction counts by type.
+type ReactionCounts struct {
+	Angry uint
+	Haha  uint
+	Like  uint
+	Love  uint
+	Sad   uint
+	Wow   uint
+}

--- a/error/error.go
+++ b/error/error.go
@@ -14,8 +14,10 @@ var (
 
 // Platform errors.
 var (
-	ErrDeviceDisabled  = errors.New("device disabled")
-	ErrInvalidPlatform = errors.New("invalid platform")
+	ErrDeviceDisabled   = errors.New("device disabled")
+	ErrInvalidPlatform  = errors.New("invalid platform")
+	ErrInvalidReaction  = errors.New("invalid reaction")
+	ErrReactionNotFound = errors.New("reaction not found")
 )
 
 // Error wrapper.
@@ -36,6 +38,16 @@ func IsDeviceDisabled(err error) bool {
 // IsInvalidPlatform indicates if err is ErrInvalidPlatform.
 func IsInvalidPlatform(err error) bool {
 	return unwrapError(err) == ErrInvalidPlatform
+}
+
+// IsInvalidReaction indicates if err is ErrInvalidReaction.
+func IsInvalidReaction(err error) bool {
+	return unwrapError(err) == ErrInvalidReaction
+}
+
+// IsReactionNotFound indicates if err is ErrReactionNotFound.
+func IsReactionNotFound(err error) bool {
+	return unwrapError(err) == ErrReactionNotFound
 }
 
 // IsNotFound indicates if err is ErrNotFouund.

--- a/handler/http/post.go
+++ b/handler/http/post.go
@@ -366,6 +366,14 @@ func (p *payloadPost) MarshalJSON() ([]byte, error) {
 		Counts: postCounts{
 			Comments: p.post.Counts.Comments,
 			Likes:    p.post.Counts.Likes,
+			Reactions: reactionCounts{
+				Angry: p.post.Counts.ReactionCounts.Angry,
+				Haha:  p.post.Counts.ReactionCounts.Haha,
+				Like:  p.post.Counts.ReactionCounts.Like,
+				Love:  p.post.Counts.ReactionCounts.Love,
+				Sad:   p.post.Counts.ReactionCounts.Sad,
+				Wow:   p.post.Counts.ReactionCounts.Wow,
+			},
 		},
 		CreatedAt:    p.post.CreatedAt,
 		ID:           strconv.FormatUint(p.post.ID, 10),
@@ -435,8 +443,18 @@ func (p *payloadPosts) MarshalJSON() ([]byte, error) {
 }
 
 type postCounts struct {
-	Comments int `json:"comments"`
-	Likes    int `json:"likes"`
+	Comments  int            `json:"comments"`
+	Likes     int            `json:"likes"`
+	Reactions reactionCounts `json:"reactions"`
+}
+
+type reactionCounts struct {
+	Angry uint `json:"angry"`
+	Haha  uint `json:"haha"`
+	Like  uint `json:"like"`
+	Love  uint `json:"love"`
+	Sad   uint `json:"sad"`
+	Wow   uint `json:"wow"`
 }
 
 type postFields struct {

--- a/handler/http/query.go
+++ b/handler/http/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tapglue/snaas/service/connection"
 	"github.com/tapglue/snaas/service/event"
 	"github.com/tapglue/snaas/service/object"
+	"github.com/tapglue/snaas/service/reaction"
 	"github.com/tapglue/snaas/service/user"
 )
 
@@ -28,6 +29,7 @@ const (
 	keyCursorBefore = "before"
 	keyLimit        = "limit"
 	keyPostID       = "postID"
+	keyReactionType = "reactionType"
 	keyState        = "state"
 	keyUserID       = "userID"
 	keyUserQuery    = "q"
@@ -256,6 +258,22 @@ func extractLimit(r *http.Request) (int, error) {
 	return limit, nil
 }
 
+func extractReactionType(r *http.Request) (reaction.Type, error) {
+	t, ok := map[string]reaction.Type{
+		"likes":   reaction.TypeLike,
+		"loves":   reaction.TypeLove,
+		"hahas":   reaction.TypeHaha,
+		"wows":    reaction.TypeWow,
+		"sads":    reaction.TypeSad,
+		"angries": reaction.TypeAngry,
+	}[mux.Vars(r)[keyReactionType]]
+	if !ok {
+		return 0, fmt.Errorf("reaction type not supported")
+	}
+
+	return t, nil
+}
+
 func extractPostID(r *http.Request) (uint64, error) {
 	return strconv.ParseUint(mux.Vars(r)[keyPostID], 10, 64)
 }
@@ -283,6 +301,10 @@ func extractPostOpts(r *http.Request) (object.QueryOptions, error) {
 	}
 
 	return opts, nil
+}
+
+func extractReactionOpts(r *http.Request) (reaction.QueryOptions, error) {
+	return reaction.QueryOptions{}, nil
 }
 
 func extractState(r *http.Request) connection.State {

--- a/handler/http/reaction.go
+++ b/handler/http/reaction.go
@@ -1,0 +1,277 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/service/reaction"
+	"github.com/tapglue/snaas/service/user"
+)
+
+// ReactionCreate creates a Reaction on the Post.
+func ReactionCreate(fn core.ReactionCreateFunc) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		var (
+			currentApp  = appFromContext(ctx)
+			currentUser = userFromContext(ctx)
+		)
+
+		postID, err := extractPostID(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		reactionType, err := extractReactionType(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		reaction, err := fn(currentApp, currentUser.ID, postID, reactionType)
+		if err != nil {
+			respondError(w, 0, err)
+			return
+		}
+
+		respondJSON(w, http.StatusCreated, &payloadReaction{reaction: reaction})
+	}
+}
+
+// ReactionDelete removes an existing Reaction for the currentUser on the Post.
+func ReactionDelete(fn core.ReactionDeleteFunc) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		var (
+			currentApp  = appFromContext(ctx)
+			currentUser = userFromContext(ctx)
+		)
+
+		postID, err := extractPostID(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		reactionType, err := extractReactionType(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		err = fn(currentApp, currentUser.ID, postID, reactionType)
+		if err != nil {
+			respondError(w, 0, err)
+			return
+		}
+
+		respondJSON(w, http.StatusNoContent, nil)
+	}
+}
+
+// ReactionListPost returns all reactions for a Post.
+func ReactionListPost(fn core.ReactionListPostFunc) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		var (
+			currentApp  = appFromContext(ctx)
+			currentUser = userFromContext(ctx)
+		)
+
+		postID, err := extractPostID(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts, err := extractReactionOpts(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts.Before, err = extractTimeCursorBefore(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts.Limit, err = extractLimit(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		feed, err := fn(currentApp, currentUser.ID, postID, opts)
+		if err != nil {
+			respondError(w, 0, err)
+			return
+		}
+
+		if len(feed.Reactions) == 0 {
+			respondJSON(w, http.StatusNoContent, nil)
+			return
+		}
+
+		respondJSON(w, http.StatusOK, &payloadReactions{
+			pagination: pagination(
+				r,
+				opts.Limit,
+				reactionCursorAfter(feed.Reactions, opts.Limit),
+				reactionCursorBefore(feed.Reactions, opts.Limit),
+			),
+			postMap:   feed.PostMap,
+			reactions: feed.Reactions,
+			userMap:   feed.UserMap,
+		})
+	}
+}
+
+// ReactionListPostByType returns all reactions for a Post.
+func ReactionListPostByType(fn core.ReactionListPostFunc) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		var (
+			currentApp  = appFromContext(ctx)
+			currentUser = userFromContext(ctx)
+		)
+
+		postID, err := extractPostID(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		reactionType, err := extractReactionType(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts, err := extractReactionOpts(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts.Before, err = extractTimeCursorBefore(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts.Limit, err = extractLimit(r)
+		if err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		opts.Types = []reaction.Type{
+			reactionType,
+		}
+
+		feed, err := fn(currentApp, currentUser.ID, postID, opts)
+		if err != nil {
+			respondError(w, 0, err)
+			return
+		}
+
+		if len(feed.Reactions) == 0 {
+			respondJSON(w, http.StatusNoContent, nil)
+			return
+		}
+
+		respondJSON(w, http.StatusOK, &payloadReactions{
+			pagination: pagination(
+				r,
+				opts.Limit,
+				reactionCursorAfter(feed.Reactions, opts.Limit),
+				reactionCursorBefore(feed.Reactions, opts.Limit),
+			),
+			postMap:   feed.PostMap,
+			reactions: feed.Reactions,
+			userMap:   feed.UserMap,
+		})
+	}
+}
+
+type payloadReaction struct {
+	reaction *reaction.Reaction
+}
+
+func (p *payloadReaction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ID        string        `json:"id"`
+		PostID    string        `json:"post_id"`
+		Type      reaction.Type `json:"type"`
+		CreatedAt time.Time     `json:"created_at"`
+		UpdatedAt time.Time     `json:"updated_at"`
+	}{
+		ID:        strconv.FormatUint(p.reaction.ID, 10),
+		PostID:    strconv.FormatUint(p.reaction.ObjectID, 10),
+		Type:      p.reaction.Type,
+		CreatedAt: p.reaction.CreatedAt,
+		UpdatedAt: p.reaction.UpdatedAt,
+	})
+}
+
+type payloadReactions struct {
+	reactions  reaction.List
+	pagination *payloadPagination
+	postMap    core.PostMap
+	userMap    user.Map
+}
+
+func (p *payloadReactions) MarshalJSON() ([]byte, error) {
+	rs := []*payloadReaction{}
+
+	for _, r := range p.reactions {
+		rs = append(rs, &payloadReaction{reaction: r})
+	}
+
+	pm := map[string]*payloadPost{}
+
+	for id, post := range p.postMap {
+		pm[strconv.FormatUint(id, 10)] = &payloadPost{post: post}
+	}
+
+	return json.Marshal(struct {
+		Pagination     *payloadPagination      `json:"paging"`
+		PostMap        map[string]*payloadPost `json:"post_map"`
+		PostMapCount   int                     `json:"post_map_count"`
+		Reactions      []*payloadReaction      `json:"reactions"`
+		ReactionsCount int                     `json:"reactions_count"`
+		UserMap        *payloadUserMap         `json:"users"`
+		UserCount      int                     `json:"users_count"`
+	}{
+		Pagination:     p.pagination,
+		PostMap:        pm,
+		PostMapCount:   len(pm),
+		Reactions:      rs,
+		ReactionsCount: len(rs),
+		UserMap:        &payloadUserMap{userMap: p.userMap},
+		UserCount:      len(p.userMap),
+	})
+}
+
+func reactionCursorAfter(rs reaction.List, limit int) string {
+	var after string
+
+	if len(rs) != 0 {
+		after = toTimeCursor(rs[0].UpdatedAt)
+	}
+
+	return after
+}
+
+func reactionCursorBefore(rs reaction.List, limit int) string {
+	var before string
+
+	if len(rs) != 0 {
+		before = toTimeCursor(rs[len(rs)-1].UpdatedAt)
+	}
+
+	return before
+}

--- a/platform/pg/pg.go
+++ b/platform/pg/pg.go
@@ -52,12 +52,19 @@ func ClausesToWhere(clauses ...string) string {
 }
 
 // GuardIndex wraps an index creation query with a condition to prevent conflicts.
-func GuardIndex(namespace, index, query string) string {
+func GuardIndex(namespace, index, query string, args ...interface{}) string {
+	as := []interface{}{
+		index,
+		namespace,
+	}
+
+	as = append(as, args...)
+
 	return fmt.Sprintf(
 		guardIndex,
 		namespace,
 		index,
-		fmt.Sprintf(query, index, namespace),
+		fmt.Sprintf(query, as...),
 	)
 }
 

--- a/service/reaction/helper_test.go
+++ b/service/reaction/helper_test.go
@@ -1,0 +1,236 @@
+package reaction
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type prepareFunc func(t *testing.T, namespace string) Service
+
+func testServiceCount(p prepareFunc, t *testing.T) {
+	var (
+		deleted   = true
+		objectID  = uint64(rand.Int63())
+		ownerID   = uint64(rand.Int63())
+		namespace = "service_count"
+		service   = p(t, namespace)
+	)
+
+	for _, r := range testList(objectID, ownerID) {
+		_, err := service.Put(namespace, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := map[*QueryOptions]uint{
+		&QueryOptions{}:                                  51, // All
+		&QueryOptions{Deleted: &deleted}:                 5,  // Deleted
+		&QueryOptions{ObjectIDs: []uint64{objectID}}:     3,  // By Object
+		&QueryOptions{OwnerIDs: []uint64{ownerID}}:       11, // By Owner
+		&QueryOptions{Types: []Type{TypeLike}}:           26, // Likes
+		&QueryOptions{Types: []Type{TypeLove}}:           9,  // Loves
+		&QueryOptions{Types: []Type{TypeHaha}}:           3,  // Hahas
+		&QueryOptions{Types: []Type{TypeWow}}:            7,  // Wows
+		&QueryOptions{Types: []Type{TypeSad}}:            1,  // Sads
+		&QueryOptions{Types: []Type{TypeAngry}}:          5,  // Angries
+		&QueryOptions{Types: []Type{TypeLike, TypeHaha}}: 29, // Combined
+	}
+
+	for opts, want := range cases {
+		have, err := service.Count(namespace, *opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}
+
+func testServicePut(p prepareFunc, t *testing.T) {
+	var (
+		deleted   = true
+		enabled   = false
+		namespace = "service_put"
+		service   = p(t, namespace)
+	)
+
+	created, err := service.Put(namespace, testReactionLike())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := service.Query(namespace, QueryOptions{
+		Deleted: &enabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(list), 1; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	if have, want := list[0], created; !reflect.DeepEqual(have, want) {
+		t.Fatalf("\nhave %v\nwant %v", have, want)
+	}
+
+	created.Deleted = true
+
+	updated, err := service.Put(namespace, created)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err = service.Query(namespace, QueryOptions{
+		Deleted: &deleted,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(list), 1; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+
+	if have, want := list[0], updated; !reflect.DeepEqual(have, want) {
+		t.Fatalf("\nhave %v\nwant %v", have, want)
+	}
+}
+
+func testServiceQuery(p prepareFunc, t *testing.T) {
+	var (
+		deleted   = true
+		objectID  = uint64(rand.Int63())
+		ownerID   = uint64(rand.Int63())
+		namespace = "service_query"
+		service   = p(t, namespace)
+	)
+
+	for _, r := range testList(objectID, ownerID) {
+		_, err := service.Put(namespace, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	created, err := service.Put(namespace, testReactionLike())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	cases := map[*QueryOptions]uint{
+		&QueryOptions{}:                                  52, // All
+		&QueryOptions{Before: created.UpdatedAt}:         51, // Deleted
+		&QueryOptions{Deleted: &deleted}:                 5,  // Deleted
+		&QueryOptions{Limit: 11}:                         11, // Deleted
+		&QueryOptions{ObjectIDs: []uint64{objectID}}:     3,  // By Object
+		&QueryOptions{OwnerIDs: []uint64{ownerID}}:       11, // By Owner
+		&QueryOptions{Types: []Type{TypeLike}}:           27, // Likes
+		&QueryOptions{Types: []Type{TypeLove}}:           9,  // Loves
+		&QueryOptions{Types: []Type{TypeHaha}}:           3,  // Hahas
+		&QueryOptions{Types: []Type{TypeWow}}:            7,  // Wows
+		&QueryOptions{Types: []Type{TypeSad}}:            1,  // Sads
+		&QueryOptions{Types: []Type{TypeAngry}}:          5,  // Angries
+		&QueryOptions{Types: []Type{TypeLike, TypeHaha}}: 30, // Combined
+	}
+
+	for opts, want := range cases {
+		list, err := service.Query(namespace, *opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have := uint(len(list)); have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}
+
+func testList(objectID, ownerID uint64) List {
+	rs := List{}
+
+	for i := 0; i < 7; i++ {
+		rs = append(rs, testReactionLike())
+	}
+
+	for i := 0; i < 5; i++ {
+		r := testReactionLike()
+
+		r.Deleted = true
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 3; i++ {
+		r := testReactionLike()
+
+		r.ObjectID = objectID
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 11; i++ {
+		r := testReactionLike()
+
+		r.OwnerID = ownerID
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 9; i++ {
+		r := testReactionLike()
+
+		r.Type = TypeLove
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 3; i++ {
+		r := testReactionLike()
+
+		r.Type = TypeHaha
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 7; i++ {
+		r := testReactionLike()
+
+		r.Type = TypeWow
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 1; i++ {
+		r := testReactionLike()
+
+		r.Type = TypeSad
+
+		rs = append(rs, r)
+	}
+
+	for i := 0; i < 5; i++ {
+		r := testReactionLike()
+
+		r.Type = TypeAngry
+
+		rs = append(rs, r)
+	}
+
+	return rs
+}
+
+func testReactionLike() *Reaction {
+	return &Reaction{
+		ObjectID: uint64(rand.Int63()),
+		OwnerID:  uint64(rand.Int63()),
+		Type:     TypeLike,
+	}
+}

--- a/service/reaction/instrumentation.go
+++ b/service/reaction/instrumentation.go
@@ -1,0 +1,123 @@
+package reaction
+
+import (
+	"time"
+
+	kitmetrics "github.com/go-kit/kit/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tapglue/snaas/platform/metrics"
+)
+
+const serviceName = "reaction"
+
+type instrumentService struct {
+	component string
+	errCount  kitmetrics.Counter
+	next      Service
+	opCount   kitmetrics.Counter
+	opLatency *prometheus.HistogramVec
+	store     string
+}
+
+// InstrumentServiceMiddleware observes key apsects of Service operations and exposes
+// Prometheus metrics.
+func InstrumentServiceMiddleware(
+	component, store string,
+	errCount kitmetrics.Counter,
+	opCount kitmetrics.Counter,
+	opLatency *prometheus.HistogramVec,
+) ServiceMiddleware {
+	return func(next Service) Service {
+		return &instrumentService{
+			component: component,
+			errCount:  errCount,
+			next:      next,
+			opCount:   opCount,
+			opLatency: opLatency,
+			store:     store,
+		}
+	}
+}
+
+func (s *instrumentService) Count(
+	ns string,
+	opts QueryOptions,
+) (count uint, err error) {
+	defer func(begin time.Time) {
+		s.track("Count", ns, begin, err)
+	}(time.Now())
+
+	return s.next.Count(ns, opts)
+}
+
+func (s *instrumentService) Put(
+	ns string,
+	input *Reaction,
+) (output *Reaction, err error) {
+	defer func(begin time.Time) {
+		s.track("Put", ns, begin, err)
+	}(time.Now())
+
+	return s.next.Put(ns, input)
+}
+
+func (s *instrumentService) Query(
+	ns string,
+	opts QueryOptions,
+) (list List, err error) {
+	defer func(begin time.Time) {
+		s.track("Query", ns, begin, err)
+	}(time.Now())
+
+	return s.next.Query(ns, opts)
+}
+
+func (s *instrumentService) Setup(ns string) (err error) {
+	defer func(begin time.Time) {
+		s.track("Setup", ns, begin, err)
+	}(time.Now())
+
+	return s.next.Setup(ns)
+}
+
+func (s *instrumentService) Teardown(ns string) (err error) {
+	defer func(begin time.Time) {
+		s.track("Teardown", ns, begin, err)
+	}(time.Now())
+
+	return s.next.Teardown(ns)
+}
+
+func (s *instrumentService) track(
+	method, namespace string,
+	begin time.Time,
+	err error,
+) {
+	if err != nil {
+		s.errCount.With(
+			metrics.FieldComponent, s.component,
+			metrics.FieldMethod, method,
+			metrics.FieldNamespace, namespace,
+			metrics.FieldService, serviceName,
+			metrics.FieldStore, s.store,
+		).Add(1)
+
+		return
+	}
+
+	s.opCount.With(
+		metrics.FieldComponent, s.component,
+		metrics.FieldMethod, method,
+		metrics.FieldNamespace, namespace,
+		metrics.FieldService, serviceName,
+		metrics.FieldStore, s.store,
+	).Add(1)
+
+	s.opLatency.With(prometheus.Labels{
+		metrics.FieldComponent: s.component,
+		metrics.FieldMethod:    method,
+		metrics.FieldNamespace: namespace,
+		metrics.FieldService:   serviceName,
+		metrics.FieldStore:     s.store,
+	}).Observe(time.Since(begin).Seconds())
+}

--- a/service/reaction/logging.go
+++ b/service/reaction/logging.go
@@ -1,0 +1,119 @@
+package reaction
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+type logService struct {
+	logger log.Logger
+	next   Service
+}
+
+// LogServiceMiddleware given a logger wraps the next Service with logging
+// capabilities.
+func LogServiceMiddleware(logger log.Logger, store string) ServiceMiddleware {
+	return func(next Service) Service {
+		logger = log.NewContext(logger).With(
+			"service", "reaction",
+			"store", store,
+		)
+
+		return &logService{logger: logger, next: next}
+	}
+}
+
+func (s *logService) Count(ns string, opts QueryOptions) (count uint, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"count", count,
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"method", "Count",
+			"namespace", ns,
+			"opts", opts,
+		}
+
+		if err != nil {
+			ps = append(ps, "err", err)
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.Count(ns, opts)
+}
+
+func (s *logService) Put(ns string, input *Reaction) (output *Reaction, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"method", "Put",
+			"namespace", ns,
+			"reaction_input", input,
+			"reaction_output", output,
+		}
+
+		if err != nil {
+			ps = append(ps, "err", err)
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.Put(ns, input)
+}
+
+func (s *logService) Query(ns string, opts QueryOptions) (list List, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"method", "Query",
+			"namespace", ns,
+			"reaction_len", len(list),
+			"opts", opts,
+		}
+
+		if err != nil {
+			ps = append(ps, "err", err)
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.Query(ns, opts)
+}
+
+func (s *logService) Setup(ns string) (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"method", "Setup",
+			"namespace", ns,
+		}
+
+		if err != nil {
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.Setup(ns)
+}
+
+func (s *logService) Teardown(ns string) (err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"method", "Teardown",
+			"namespace", ns,
+		}
+
+		if err != nil {
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.Setup(ns)
+}

--- a/service/reaction/mem.go
+++ b/service/reaction/mem.go
@@ -1,0 +1,174 @@
+package reaction
+
+import (
+	"time"
+
+	serr "github.com/tapglue/snaas/error"
+	"github.com/tapglue/snaas/platform/flake"
+)
+
+type memService struct {
+	reactions map[string]Map
+}
+
+// MemService returns a memory based Service implementation.
+func MemService() Service {
+	return &memService{
+		reactions: map[string]Map{},
+	}
+}
+
+func (s *memService) Count(ns string, opts QueryOptions) (uint, error) {
+	if err := s.Setup(ns); err != nil {
+		return 0, err
+	}
+
+	return uint(len(filterList(s.reactions[ns].ToList(), opts))), nil
+}
+
+func (s *memService) Put(ns string, input *Reaction) (*Reaction, error) {
+	if err := s.Setup(ns); err != nil {
+		return nil, err
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	var (
+		bucket = s.reactions[ns]
+		now    = time.Now().UTC()
+	)
+
+	if input.ID == 0 {
+		id, err := flake.NextID(flakeNamespace(ns))
+		if err != nil {
+			return nil, err
+		}
+
+		if input.CreatedAt.IsZero() {
+			input.CreatedAt = now
+		}
+
+		input.ID = id
+	} else {
+		keep := false
+
+		for _, input := range bucket {
+			if input.ID == input.ID {
+				keep = true
+				input.CreatedAt = input.CreatedAt
+			}
+		}
+
+		if !keep {
+			return nil, serr.Wrap(serr.ErrReactionNotFound, "%d", input.ID)
+		}
+	}
+
+	input.UpdatedAt = now
+	bucket[input.ID] = copyReaction(input)
+
+	return copyReaction(input), nil
+}
+
+func (s *memService) Query(ns string, opts QueryOptions) (List, error) {
+	if err := s.Setup(ns); err != nil {
+		return nil, err
+	}
+
+	rs := filterList(s.reactions[ns].ToList(), opts)
+
+	if opts.Limit > 0 && len(rs) > opts.Limit {
+		rs = rs[:opts.Limit]
+	}
+
+	return rs, nil
+}
+
+func (s *memService) Setup(ns string) error {
+	if _, ok := s.reactions[ns]; !ok {
+		s.reactions[ns] = Map{}
+	}
+
+	return nil
+}
+
+func (s *memService) Teardown(ns string) error {
+	if _, ok := s.reactions[ns]; ok {
+		delete(s.reactions, ns)
+	}
+
+	return nil
+}
+
+func copyReaction(r *Reaction) *Reaction {
+	old := *r
+	return &old
+}
+
+func filterList(rs List, opts QueryOptions) List {
+	fs := List{}
+
+	for _, r := range rs {
+		if !opts.Before.IsZero() {
+			if r.UpdatedAt.After(opts.Before) || r.UpdatedAt == opts.Before {
+				continue
+			}
+		}
+
+		if opts.Deleted != nil && r.Deleted != *opts.Deleted {
+			continue
+		}
+
+		if !inIDs(r.ObjectID, opts.ObjectIDs) {
+			continue
+		}
+
+		if !inIDs(r.OwnerID, opts.OwnerIDs) {
+			continue
+		}
+
+		if !inTypes(r.Type, opts.Types) {
+			continue
+		}
+
+		fs = append(fs, r)
+	}
+
+	return fs
+}
+
+func inIDs(id uint64, ids []uint64) bool {
+	if len(ids) == 0 {
+		return true
+	}
+
+	keep := false
+
+	for _, i := range ids {
+		if id == i {
+			keep = true
+			break
+		}
+	}
+
+	return keep
+}
+
+func inTypes(t Type, ts []Type) bool {
+	if len(ts) == 0 {
+		return true
+	}
+
+	keep := false
+
+	for _, i := range ts {
+		if t == i {
+			keep = true
+			break
+		}
+	}
+
+	return keep
+}

--- a/service/reaction/mem_test.go
+++ b/service/reaction/mem_test.go
@@ -1,0 +1,19 @@
+package reaction
+
+import "testing"
+
+func TestMemCount(t *testing.T) {
+	testServiceCount(prepareMem, t)
+}
+
+func TestMemPut(t *testing.T) {
+	testServicePut(prepareMem, t)
+}
+
+func TestMemQuery(t *testing.T) {
+	testServiceQuery(prepareMem, t)
+}
+
+func prepareMem(t *testing.T, ns string) Service {
+	return MemService()
+}

--- a/service/reaction/postgres.go
+++ b/service/reaction/postgres.go
@@ -1,0 +1,387 @@
+package reaction
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/tapglue/snaas/platform/flake"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/tapglue/snaas/platform/pg"
+)
+
+const (
+	pgInsertReaction = `
+		INSERT INTO %s.reactions(
+			deleted, id, object_id, owner_id, type, created_at, updated_at
+		) VALUES(
+			$1, $2, $3, $4, $5, $6, $7
+		)`
+	pgUpdateReaction = `
+		UPDATE
+			%s.reactions
+		SET
+			deleted = $2,
+			updated_at = $3
+		WHERE
+			id = $1`
+
+	pgCountReactions = `SELECT count(*) FROM %s.reactions %s`
+	pgListReactions  = `
+		SELECT
+			deleted, id, object_id, owner_id, type, created_at, updated_at
+		FROM
+			%s.reactions
+		%s`
+
+	pgClauseBefore    = `updated_at < ?`
+	pgClauseDeleted   = `deleted = ?`
+	pgClauseObjectIDs = `object_id IN (?)`
+	pgClauseOwnerIDs  = `owner_id IN (?)`
+	pgClauseTypes     = `type IN (?)`
+
+	pgOrderUpdatedAt = `ORDER BY updated_at DESC`
+
+	pgCreateSchema = `CREATE SCHEMA IF NOT EXISTS %s`
+	pgCreateTable  = `CREATE TABLE IF NOT EXISTS %s.reactions(
+		deleted BOOL DEFAULT false,
+		id BIGINT PRIMARY KEY,
+		object_id BIGINT NOT NULL,
+		owner_id BIGINT NOT NULL,
+		type INT NOT NULL,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL
+	)`
+	pgDropTable = `DROP TABLE IF EXISTS %s.reactions`
+
+	pgIndexObjectByType = `
+		CREATE INDEX
+			%s
+		ON
+			%s.reactions
+		USING
+			btree(object_id, updated_at DESC)
+		WHERE
+			deleted = false
+			AND type = %d`
+	pgIndexOwner = `
+		CREATE INDEX
+			%s
+		ON
+			%s.reactions
+		USING
+			btree(object_id, owner_id, type)`
+)
+
+type pgService struct {
+	db *sqlx.DB
+}
+
+// PostgresService returns a Postgres based Service inplementation.
+func PostgresService(db *sqlx.DB) Service {
+	return &pgService{
+		db: db,
+	}
+}
+
+func (s *pgService) Count(ns string, opts QueryOptions) (uint, error) {
+	where, params, err := convertOpts(opts)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.countEvents(ns, where, params...)
+}
+
+func (s *pgService) Put(ns string, r *Reaction) (*Reaction, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
+	if r.ID == 0 {
+		return s.insert(ns, r)
+	}
+
+	return s.update(ns, r)
+}
+
+func (s *pgService) Query(ns string, opts QueryOptions) (List, error) {
+	where, params, err := convertOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.listEvents(ns, where, params...)
+}
+
+func (s *pgService) Setup(ns string) error {
+	qs := []string{
+		fmt.Sprintf(pgCreateSchema, ns),
+		fmt.Sprintf(pgCreateTable, ns),
+
+		// Indexes
+		pg.GuardIndex(ns, "reaction_object_like", pgIndexObjectByType, TypeLike),
+		pg.GuardIndex(ns, "reaction_object_love", pgIndexObjectByType, TypeLove),
+		pg.GuardIndex(ns, "reaction_object_haha", pgIndexObjectByType, TypeHaha),
+		pg.GuardIndex(ns, "reaction_object_wow", pgIndexObjectByType, TypeWow),
+		pg.GuardIndex(ns, "reaction_object_sad", pgIndexObjectByType, TypeSad),
+		pg.GuardIndex(ns, "reaction_object_angry", pgIndexObjectByType, TypeAngry),
+		pg.GuardIndex(ns, "reaction_owner_type", pgIndexOwner),
+	}
+
+	for _, q := range qs {
+		if _, err := s.db.Exec(q); err != nil {
+			return fmt.Errorf("setup '%s': %s", q, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *pgService) Teardown(ns string) error {
+	qs := []string{
+		fmt.Sprintf(pgDropTable, ns),
+	}
+
+	for _, q := range qs {
+		if _, err := s.db.Exec(q); err != nil {
+			return fmt.Errorf("teardown '%s': %s", q, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *pgService) countEvents(
+	ns, where string,
+	params ...interface{},
+) (uint, error) {
+	var (
+		query = fmt.Sprintf(pgCountReactions, ns, where)
+
+		count uint
+	)
+
+	err := s.db.Get(&count, query, params...)
+	if err != nil && pg.IsRelationNotFound(pg.WrapError(err)) {
+		if err := s.Setup(ns); err != nil {
+			return count, err
+		}
+
+		err = s.db.Get(&count, query, params...)
+	}
+
+	return count, err
+}
+
+func (s *pgService) insert(ns string, r *Reaction) (*Reaction, error) {
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = time.Now().UTC()
+	}
+
+	ts, err := time.Parse(pg.TimeFormat, r.CreatedAt.UTC().Format(pg.TimeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	r.CreatedAt = ts
+	r.UpdatedAt = ts
+
+	id, err := flake.NextID(flakeNamespace(ns))
+	if err != nil {
+		return nil, err
+	}
+
+	r.ID = id
+
+	var (
+		params = []interface{}{
+			r.Deleted,
+			r.ID,
+			r.ObjectID,
+			r.OwnerID,
+			r.Type,
+			r.CreatedAt,
+			r.UpdatedAt,
+		}
+		query = fmt.Sprintf(pgInsertReaction, ns)
+	)
+
+	_, err = s.db.Exec(query, params...)
+	if err != nil && pg.IsRelationNotFound(pg.WrapError(err)) {
+		if err := s.Setup(ns); err != nil {
+			return nil, err
+		}
+
+		_, err = s.db.Exec(query, params...)
+	}
+
+	return r, err
+}
+
+func (s *pgService) listEvents(
+	ns, where string,
+	params ...interface{},
+) (List, error) {
+	query := fmt.Sprintf(pgListReactions, ns, where)
+
+	rows, err := s.db.Query(query, params...)
+	if err != nil {
+		if pg.IsRelationNotFound(pg.WrapError(err)) {
+			if err := s.Setup(ns); err != nil {
+				return nil, err
+			}
+
+			return s.listEvents(ns, where, params...)
+		}
+	}
+	defer rows.Close()
+
+	rs := List{}
+
+	for rows.Next() {
+		var (
+			reaction = &Reaction{}
+		)
+
+		err := rows.Scan(
+			&reaction.Deleted,
+			&reaction.ID,
+			&reaction.ObjectID,
+			&reaction.OwnerID,
+			&reaction.Type,
+			&reaction.CreatedAt,
+			&reaction.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		reaction.CreatedAt = reaction.CreatedAt.UTC()
+		reaction.UpdatedAt = reaction.UpdatedAt.UTC()
+
+		rs = append(rs, reaction)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return rs, nil
+}
+
+func (s *pgService) update(ns string, r *Reaction) (*Reaction, error) {
+	now, err := time.Parse(pg.TimeFormat, time.Now().UTC().Format(pg.TimeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	r.UpdatedAt = now
+
+	var (
+		params = []interface{}{
+			r.ID,
+			r.Deleted,
+			r.UpdatedAt,
+		}
+		query = fmt.Sprintf(pgUpdateReaction, ns)
+	)
+
+	_, err = s.db.Exec(query, params...)
+	if err != nil && pg.IsRelationNotFound(pg.WrapError(err)) {
+		if err := s.Setup(ns); err != nil {
+			return nil, err
+		}
+
+		_, err = s.db.Exec(query, params...)
+	}
+
+	return r, err
+}
+
+func convertOpts(opts QueryOptions) (string, []interface{}, error) {
+	var (
+		clauses = []string{}
+		params  = []interface{}{}
+	)
+
+	if !opts.Before.IsZero() {
+		clauses = append(clauses, pgClauseBefore)
+		params = append(params, opts.Before.UTC().Format(pg.TimeFormat))
+	}
+
+	if opts.Deleted != nil {
+		clause, _, err := sqlx.In(pgClauseDeleted, []interface{}{*opts.Deleted})
+		if err != nil {
+			return "", nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, *opts.Deleted)
+	}
+
+	if len(opts.ObjectIDs) > 0 {
+		ps := []interface{}{}
+
+		for _, id := range opts.ObjectIDs {
+			ps = append(ps, id)
+		}
+
+		clause, _, err := sqlx.In(pgClauseObjectIDs, ps)
+		if err != nil {
+			return "", nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if len(opts.OwnerIDs) > 0 {
+		ps := []interface{}{}
+
+		for _, id := range opts.OwnerIDs {
+			ps = append(ps, id)
+		}
+
+		clause, _, err := sqlx.In(pgClauseOwnerIDs, ps)
+		if err != nil {
+			return "", nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if len(opts.Types) > 0 {
+		ps := []interface{}{}
+
+		for _, t := range opts.Types {
+			ps = append(ps, t)
+		}
+
+		clause, _, err := sqlx.In(pgClauseTypes, ps)
+		if err != nil {
+			return "", nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	where := ""
+
+	if len(clauses) > 0 {
+		where = sqlx.Rebind(sqlx.DOLLAR, pg.ClausesToWhere(clauses...))
+	}
+
+	if !opts.Before.IsZero() {
+		where = fmt.Sprintf("%s\n%s", where, pgOrderUpdatedAt)
+	}
+
+	if opts.Limit > 0 {
+		where = fmt.Sprintf("%s\nLIMIT %d", where, opts.Limit)
+	}
+
+	return where, params, nil
+}

--- a/service/reaction/postgres_test.go
+++ b/service/reaction/postgres_test.go
@@ -1,0 +1,60 @@
+// +build integration
+
+package reaction
+
+import (
+	"flag"
+	"fmt"
+	"os/user"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+)
+
+var pgURL string
+
+func TestPostgresCount(t *testing.T) {
+	testServiceCount(preparePostgres, t)
+}
+
+func TestPostgresPut(t *testing.T) {
+	testServicePut(preparePostgres, t)
+}
+
+func TestPostgresQuery(t *testing.T) {
+	testServiceQuery(preparePostgres, t)
+}
+
+func preparePostgres(t *testing.T, namespace string) Service {
+	db, err := sqlx.Connect("postgres", pgURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := PostgresService(db)
+
+	err = s.Teardown(namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return s
+}
+
+func init() {
+	user, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	d := fmt.Sprintf(
+		"postgres://%s@127.0.0.1:5432/tapglue_test?sslmode=disable&connect_timeout=5",
+		user.Username,
+	)
+
+	url := flag.String("postgres.url", d, "Postgres connection URL")
+	flag.Parse()
+
+	pgURL = *url
+}

--- a/service/reaction/reaction.go
+++ b/service/reaction/reaction.go
@@ -1,0 +1,118 @@
+package reaction
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	serr "github.com/tapglue/snaas/error"
+	"github.com/tapglue/snaas/platform/service"
+)
+
+// Supported Reaction types.
+const (
+	TypeLike Type = iota + 1
+	TypeLove
+	TypeHaha
+	TypeWow
+	TypeSad
+	TypeAngry
+)
+
+// List is a collection of Reaction.
+type List []*Reaction
+
+func (rs List) Len() int {
+	return len(rs)
+}
+
+func (rs List) Less(i, j int) bool {
+	return rs[i].UpdatedAt.After(rs[j].UpdatedAt)
+}
+
+func (rs List) Swap(i, j int) {
+	rs[i], rs[j] = rs[j], rs[i]
+}
+
+// OwnerIDs returns the list of owner ids for the Reaction collection.
+func (rs List) OwnerIDs() []uint64 {
+	is := []uint64{}
+
+	for _, r := range rs {
+		is = append(is, r.OwnerID)
+	}
+
+	return is
+}
+
+// Map is a Reaction collection with their id as index.
+type Map map[uint64]*Reaction
+
+func (m Map) ToList() List {
+	rs := List{}
+
+	for _, r := range m {
+		rs = append(rs, r)
+	}
+
+	sort.Sort(rs)
+
+	return rs
+}
+
+// QueryOptions to narrow-down queries.
+type QueryOptions struct {
+	Before    time.Time `json:"-"`
+	Deleted   *bool     `json:"deleted,omitempty"`
+	Limit     int       `json:"-"`
+	ObjectIDs []uint64  `json:"object_ids"`
+	OwnerIDs  []uint64  `json:"owner_ids"`
+	Types     []Type    `json:"types"`
+}
+
+// Reaction is the building block to express interactions on Objects/Posts.
+type Reaction struct {
+	Deleted   bool
+	ID        uint64
+	ObjectID  uint64
+	OwnerID   uint64
+	Type      Type
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Validate checks for semantic correctness.
+func (r *Reaction) Validate() error {
+	if r.ObjectID == 0 {
+		return serr.Wrap(serr.ErrInvalidReaction, "missing object id")
+	}
+
+	if r.OwnerID == 0 {
+		return serr.Wrap(serr.ErrInvalidReaction, "missing owner id")
+	}
+
+	if r.Type < TypeLike || r.Type > TypeAngry {
+		return serr.Wrap(serr.ErrInvalidReaction, "unspported type '%d'", r.Type)
+	}
+
+	return nil
+}
+
+// Service for Reaction interactions.
+type Service interface {
+	service.Lifecycle
+
+	Count(namespace string, opts QueryOptions) (uint, error)
+	Put(namespace string, reaction *Reaction) (*Reaction, error)
+	Query(namespace string, opts QueryOptions) (List, error)
+}
+
+// ServiceMiddleware is a chainable behaviour modifier for Service.
+type ServiceMiddleware func(Service) Service
+
+// Type is used to distinct Reactions by type.
+type Type uint
+
+func flakeNamespace(ns string) string {
+	return fmt.Sprintf("%s_%s", ns, "reactions")
+}

--- a/service/reaction/reactions_test.go
+++ b/service/reaction/reactions_test.go
@@ -1,0 +1,25 @@
+package reaction
+
+import (
+	"testing"
+
+	serr "github.com/tapglue/snaas/error"
+)
+
+func TestReactionValidate(t *testing.T) {
+	var (
+		like  = testReactionLike()
+		cases = List{
+			{}, // Missign ObjectID
+			{ObjectID: like.ObjectID},                                 // Missing OwnerID
+			{ObjectID: like.ObjectID, OwnerID: like.OwnerID},          // Unsupported Type
+			{ObjectID: like.ObjectID, OwnerID: like.OwnerID, Type: 7}, // Unsupported Type
+		}
+	)
+
+	for _, r := range cases {
+		if have, want := r.Validate(), serr.ErrInvalidReaction; !serr.IsInvalidReaction(have) {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}


### PR DESCRIPTION
To avoid a singular type of reaction to Posts which ultimately leads to a gap in the expressiveness for users we want to follow the prominent example of other social networks and make a range of emotions available to our customers which they can expose as interactions on Posts and potentially other entities like Comments and Events themselves in the future. The proposed set of reactions includes six initial reactions including the already supported `like`:
- `like`: general endorsement
- `love`: heavily endorsed
- `haha`: entertained
- `wow`: impressed
- `sad`:
- `angry`: outraged

### API

Reaction read payload:

``` json
{
    "post_id": "321",
    "type": "sad",
    "user_id": "123"
}
```

Post read payload additions:

``` json
{
    "count": {
        "reactions": {
            "angry": 12,
            "haha": 5,
            "like": 3,
            "love": 1,
            "sad": 17,
            "wow": 4
        }
    }
}
```

The surface will be extended under the Posts namespace and offers an endpoint for reaction with the minimum CRUD capabilities to list the reactions and create and delete per user. Those will offer the same idempotent characteristics that likes offer as a single reaction per user to a post is a binary thing.
- `GET /posts/<postID>/reactions[?type=like|love|haha|wow|sad|angry]`: List all or filtered reactions for the Post.
- `PUT /posts/<postID>/reactions/<like|love|haha|wow|sad|angry>`: Create typed reaction for current uesr if not exists.
- `DELETE /posts/<postID>/reactions/<like|love|haha|wow|sad|angry>`: Delete typed reaction for current user if exists.

Additionally we provide endpoints for reactions per user.
- `GET /me/reactions[?type=like|love|haha|wow|sad|angry]`: List all or filtered reactions for the current user.
- `GET /users/<userID>/reactions[?type=like|love|haha|wow|sad|angry]`: List all or filtered reactions for the user.
### Internal

In order to support the more diverse use-cases around reactions we plan to introduce a new entity with corresponding service.

``` go
import (
    "github.com/tapglue/multiverse/platform/metrics"
    "github.com/tapglue/multiverse/platform/service"
)

// ReactionType variants available.
const (
    TypeLike ReactionType = iota
    TypeLove
    TypeHaha
    TypeWow
    TypeSad
    TypeAngry
)

// List is a Reaction collection.
type List []*Reaction

// QueryOptions are passed to narrow down queries.
type QueryOptions struct {
    ObjectIDs []uint64
    Types     []ReactionType
    UserIDs   []uint64
}

// Reaction is a user reaction on an entity on an emotional range.
type Reaction struct {
    ObjectID uint64
    Type     ReactionType
    UserID   uint64
}

// ReactionType is type of Reactions.
type ReactionType uint8

// Service for Reaction interactions.
type Service interface {
    metrics.BucketByDay
    service.Lifecycle

    Count(namespace string, opts QueryOptions) (int, error)
    Put(namespace string, object *Reaction) (*Reaction, error)
    Query(namespace string, opts QueryOptions) (List, error)
}
```

### Questions

* How extensible is the `type` to potentially support more reactions? @onurakpolat
* Is there a way to support reactions of type emoji with the emoji in the payload? (We could still translate the emoji into meaningful annotation) @onurakpolat

### Estimations
- new Reaction service: 2 days
- implement Post endpoints: 2 days
- implement User endpoints: 1 day
- implement Android: 1.5 days
- implement iOS: 1.5 days