### PR TITLE
Fix uniqueness constrain on devices

### DIFF
--- a/core/device.go
+++ b/core/device.go
@@ -185,8 +185,8 @@ func DeviceUpdate(devices device.Service) DeviceUpdateFunc {
 	) error {
 		ds, err := devices.Query(currentApp.Namespace(), device.QueryOptions{
 			Deleted: &defaultDeleted,
-			DeviceIDs: []string{
-				deviceID,
+			Platforms: []device.Platform{
+				platform,
 			},
 			UserIDs: []uint64{
 				origin.UserID,
@@ -196,26 +196,24 @@ func DeviceUpdate(devices device.Service) DeviceUpdateFunc {
 			return err
 		}
 
-		if len(ds) > 0 && ds[0].Token == token {
-			return nil
-		}
+		d := &device.Device{}
 
-		var d *device.Device
+		for _, dev := range ds {
+			if dev.DeviceID == deviceID && dev.Token == token {
+				return nil
+			}
 
-		if len(ds) > 0 {
-			d = ds[0]
-			d.Disabled = false
-			d.Token = token
-		} else {
-			d = &device.Device{
-				DeviceID: deviceID,
-				Disabled: false,
-				Language: language,
-				Platform: platform,
-				Token:    token,
-				UserID:   origin.UserID,
+			if dev.DeviceID == deviceID || dev.Token == token {
+				d = dev
 			}
 		}
+
+		d.DeviceID = deviceID
+		d.Disabled = false
+		d.Language = language
+		d.Platform = platform
+		d.Token = token
+		d.UserID = origin.UserID
 
 		_, err = devices.Put(currentApp.Namespace(), d)
 		if err != nil {

--- a/service/device/postgres.go
+++ b/service/device/postgres.go
@@ -20,11 +20,12 @@ const (
 			%s.devices
 		SET
 			deleted = $2,
-			disabled = $3,
-			endpoint_arn = $4,
-			language = $5,
-			token = $6,
-			updated_at = $7
+			device_id = $3,
+			disabled = $4,
+			endpoint_arn = $5,
+			language = $6,
+			token = $7,
+			updated_at = $8
 		WHERE
 			id = $1`
 
@@ -153,6 +154,7 @@ func (s *pgService) Put(ns string, d *Device) (*Device, error) {
 		params = []interface{}{
 			d.ID,
 			d.Deleted,
+			d.DeviceID,
 			d.Disabled,
 			d.EndpointARN,
 			d.Language,


### PR DESCRIPTION
Up until now we used device_id and user_id to check for uniqueness, which is not reliable when installation of an app from mixed sources takes place as the device_id might change and the token stays the same. This will result in multiple registered devices and lead to notification duplicates.