### PR TITLE
Add relation information in post lists

### DIFF
--- a/cmd/gateway-http/gateway-http.go
+++ b/cmd/gateway-http/gateway-http.go
@@ -598,7 +598,7 @@ func main() {
 		handler.Wrap(
 			withUser,
 			handler.PostListAll(
-				core.PostListAll(events, objects, users),
+				core.PostListAll(connections, events, objects, users),
 			),
 		),
 	)

--- a/core/post.go
+++ b/core/post.go
@@ -221,6 +221,7 @@ type PostListAllFunc func(
 
 // PostListAll returns all objects which are of type post.
 func PostListAll(
+	connections connection.Service,
 	events event.Service,
 	objects object.Service,
 	users user.Service,
@@ -257,6 +258,13 @@ func PostListAll(
 		um, err := user.MapFromIDs(users, currentApp.Namespace(), ps.OwnerIDs()...)
 		if err != nil {
 			return nil, err
+		}
+
+		for _, u := range um {
+			err = enrichRelation(connections, currentApp, origin, u)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return &PostFeed{
@@ -336,6 +344,13 @@ func PostListUser(
 		um, err := user.MapFromIDs(users, currentApp.Namespace(), ps.OwnerIDs()...)
 		if err != nil {
 			return nil, err
+		}
+
+		for _, u := range um {
+			err = enrichRelation(connections, currentApp, origin, u)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return &PostFeed{

--- a/core/post_test.go
+++ b/core/post_test.go
@@ -5,11 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/tapglue/snaas/service/connection"
-
-	"github.com/tapglue/snaas/service/event"
-
 	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/connection"
+	"github.com/tapglue/snaas/service/event"
 	"github.com/tapglue/snaas/service/object"
 	"github.com/tapglue/snaas/service/user"
 )
@@ -136,11 +134,12 @@ func TestPostDelete(t *testing.T) {
 
 func TestPostListAll(t *testing.T) {
 	var (
-		app, owner = testSetupPost()
-		events     = event.MemService()
-		objects    = object.MemService()
-		users      = user.MemService()
-		fn         = PostListAll(events, objects, users)
+		app, owner  = testSetupPost()
+		connections = connection.MemService()
+		events      = event.MemService()
+		objects     = object.MemService()
+		users       = user.MemService()
+		fn          = PostListAll(connections, events, objects, users)
 	)
 
 	feed, err := fn(app, owner.ID, object.QueryOptions{})


### PR DESCRIPTION
To be consistent with other lists and the company entities meta information we add relation status to users returned in post lists.