### PR TITLE
Add Public routing

### DIFF
--- a/infrastructure/terraform/template/network.tf
+++ b/infrastructure/terraform/template/network.tf
@@ -3,9 +3,9 @@ provider "aws" {
 }
 
 resource "aws_vpc" "env" {
-  cidr_block            = "10.0.0.0/16"
-  enable_dns_support    = true
-  enable_dns_hostnames  = true
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
 
   tags {
     Name = "${var.env}"
@@ -22,10 +22,12 @@ resource "aws_internet_gateway" "env" {
 
 resource "aws_nat_gateway" "env" {
   allocation_id = "${aws_eip.nat.id}"
-  depends_on    = [
+
+  depends_on = [
     "aws_internet_gateway.env",
   ]
-  subnet_id     = "${aws_subnet.perimeter-a.id}"
+
+  subnet_id = "${aws_subnet.perimeter-a.id}"
 }
 
 resource "aws_eip" "nat" {
@@ -68,19 +70,19 @@ resource "aws_route_table" "perimeter" {
 }
 
 resource "aws_route_table_association" "perimeter-a" {
-  route_table_id  = "${aws_route_table.perimeter.id}"
-  subnet_id       = "${aws_subnet.perimeter-a.id}"
+  route_table_id = "${aws_route_table.perimeter.id}"
+  subnet_id      = "${aws_subnet.perimeter-a.id}"
 }
 
 resource "aws_route_table_association" "perimeter-b" {
-  route_table_id  = "${aws_route_table.perimeter.id}"
-  subnet_id       = "${aws_subnet.perimeter-b.id}"
+  route_table_id = "${aws_route_table.perimeter.id}"
+  subnet_id      = "${aws_subnet.perimeter-b.id}"
 }
 
 resource "aws_subnet" "platform-a" {
-  availability_zone       = "${var.region}a"
-  cidr_block              = "10.0.2.0/23"
-  vpc_id                  = "${aws_vpc.env.id}"
+  availability_zone = "${var.region}a"
+  cidr_block        = "10.0.2.0/23"
+  vpc_id            = "${aws_vpc.env.id}"
 
   tags {
     Name = "platform-a"
@@ -88,9 +90,9 @@ resource "aws_subnet" "platform-a" {
 }
 
 resource "aws_subnet" "platform-b" {
-  availability_zone       = "${var.region}b"
-  cidr_block              = "10.0.10.0/23"
-  vpc_id                  = "${aws_vpc.env.id}"
+  availability_zone = "${var.region}b"
+  cidr_block        = "10.0.10.0/23"
+  vpc_id            = "${aws_vpc.env.id}"
 
   tags {
     Name = "platform-b"
@@ -101,7 +103,7 @@ resource "aws_route_table" "platform" {
   vpc_id = "${aws_vpc.env.id}"
 
   route {
-    cidr_block = "0.0.0.0/0"
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = "${aws_nat_gateway.env.id}"
   }
 
@@ -111,23 +113,25 @@ resource "aws_route_table" "platform" {
 }
 
 resource "aws_route_table_association" "platform-a" {
-  route_table_id  = "${aws_route_table.platform.id}"
-  subnet_id       = "${aws_subnet.platform-a.id}"
+  route_table_id = "${aws_route_table.platform.id}"
+  subnet_id      = "${aws_subnet.platform-a.id}"
 }
 
 resource "aws_route_table_association" "platform-b" {
-  route_table_id  = "${aws_route_table.platform.id}"
-  subnet_id       = "${aws_subnet.platform-b.id}"
+  route_table_id = "${aws_route_table.platform.id}"
+  subnet_id      = "${aws_subnet.platform-b.id}"
 }
 
 resource "aws_instance" "bastion" {
-  ami                     = "${var.ami_minimal["${var.region}"]}"
-  instance_type           = "t2.medium"
-  key_name                = "${aws_key_pair.access.key_name}"
-  vpc_security_group_ids  = [
+  ami           = "${var.ami_minimal["${var.region}"]}"
+  instance_type = "t2.medium"
+  key_name      = "${aws_key_pair.access.key_name}"
+
+  vpc_security_group_ids = [
     "${aws_security_group.perimeter.id}",
   ]
-  subnet_id               = "${aws_subnet.perimeter-a.id}"
+
+  subnet_id = "${aws_subnet.perimeter-a.id}"
 
   tags {
     Name = "bastion"
@@ -135,6 +139,6 @@ resource "aws_instance" "bastion" {
 }
 
 resource "aws_eip" "bastion" {
-  instance  = "${aws_instance.bastion.id}"
-  vpc       = true
+  instance = "${aws_instance.bastion.id}"
+  vpc      = true
 }

--- a/infrastructure/terraform/template/scheduling.tf
+++ b/infrastructure/terraform/template/scheduling.tf
@@ -1,26 +1,29 @@
 resource "aws_ecs_service" "gateway-http" {
-  cluster         = "${aws_ecs_cluster.service.id}"
-  depends_on      = [
+  cluster = "${aws_ecs_cluster.service.id}"
+
+  depends_on = [
     "aws_iam_instance_profile.ecs-agent-profile",
     "aws_db_instance.service-master",
     "aws_elasticache_cluster.ratelimiter",
   ]
-  deployment_maximum_percent          = 200
-  deployment_minimum_healthy_percent  = 50
-  desired_count   = 3
-  iam_role        = "${aws_iam_role.ecs-scheduler.arn}"
-  name            = "gateway-http"
-  task_definition = "${aws_ecs_task_definition.gateway-http.arn}"
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
+  desired_count                      = 3
+  iam_role                           = "${aws_iam_role.ecs-scheduler.arn}"
+  name                               = "gateway-http"
+  task_definition                    = "${aws_ecs_task_definition.gateway-http.arn}"
 
   load_balancer {
-    container_name  = "gateway-http"
-    container_port  = 8083
-    elb_name        = "${aws_elb.gateway-http.id}"
+    container_name = "gateway-http"
+    container_port = 8083
+    elb_name       = "${aws_elb.gateway-http.id}"
   }
 }
 
 resource "aws_ecs_task_definition" "gateway-http" {
-  family                = "gateway-http"
+  family = "gateway-http"
+
   container_definitions = <<EOF
 [
   {
@@ -62,20 +65,23 @@ EOF
 }
 
 resource "aws_ecs_service" "sims" {
-  cluster         = "${aws_ecs_cluster.service.id}"
-  depends_on      = [
+  cluster = "${aws_ecs_cluster.service.id}"
+
+  depends_on = [
     "aws_iam_instance_profile.ecs-agent-profile",
     "aws_db_instance.service-master",
   ]
-  deployment_maximum_percent          = 200
-  deployment_minimum_healthy_percent  = 50
-  desired_count   = 2
-  name            = "sims"
-  task_definition = "${aws_ecs_task_definition.sims.arn}"
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
+  desired_count                      = 2
+  name                               = "sims"
+  task_definition                    = "${aws_ecs_task_definition.sims.arn}"
 }
 
 resource "aws_ecs_task_definition" "sims" {
-  family                = "sims"
+  family = "sims"
+
   container_definitions = <<EOF
 [
   {

--- a/infrastructure/terraform/template/storage.tf
+++ b/infrastructure/terraform/template/storage.tf
@@ -165,7 +165,7 @@ resource "aws_elasticache_cluster" "ratelimiter" {
 }
 
 resource "aws_s3_bucket" "logs-elb" {
-  bucket        = "tapglue-snaas-${var.region}-${var.env}-logs-elb"
+  bucket        = "${var.account}-snaas-${var.region}-${var.env}-logs-elb"
   force_destroy = true
 
   policy = <<EOF
@@ -180,7 +180,7 @@ resource "aws_s3_bucket" "logs-elb" {
 				"AWS": "arn:aws:iam::${var.elb_id["${var.region}"]}:root"
 			},
 			"Action": "s3:PutObject",
-			"Resource": "arn:aws:s3:::tapglue-snaas-${var.region}-${var.env}-logs-elb/AWSLogs/${var.account}/*"
+			"Resource": "arn:aws:s3:::${var.account}-snaas-${var.region}-${var.env}-logs-elb/*"
 		}
 	]
 }

--- a/infrastructure/terraform/template/variables.tf
+++ b/infrastructure/terraform/template/variables.tf
@@ -32,6 +32,12 @@ variable "ami_minimal" {
   type        = "map"
 }
 
+variable "domain" {
+  default     = ""
+  description = "Domain for public termination of the env."
+  type        = "string"
+}
+
 variable "elb_id" {
   default = {
     "us-east-1"      = "127311923021"
@@ -95,8 +101,8 @@ variable "pg_password" {
 
 variable "version" {
   default = {
-    "gateway-http" = "95"
-    "sims"         = "95"
+    "gateway-http" = "110"
+    "sims"         = "110"
   }
 
   description = "Versions used for deployed services"


### PR DESCRIPTION
In order to make an env publicily reachable we introduce the handling of an additional zone which is part of the user input during setup. Additionally we make the use of an acm certificate to provide proper termination for the traffic layer.