### PR TITLE
Always reference the connected uesr in connection events

### DIFF
--- a/core/feed_test.go
+++ b/core/feed_test.go
@@ -188,7 +188,7 @@ func TestSourceConnection(t *testing.T) {
 		}
 	)
 
-	es, err := sourceConnection(cs, event.QueryOptions{})()
+	es, err := sourceConnection(cs, from, event.QueryOptions{})()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
As it would put additional burden on the client to distinct which user to get (target or normal) we just always use the connected user to avoid potentially breaking and spotty logic.