### PR TITLE
Implement Application Platforms

### DIFF
--- a/TODO
+++ b/TODO
@@ -16,4 +16,5 @@ infrastructure:
 code:
  ✔ move event condition code @done (16-11-11 11:10)
  ✔ add missing event indeces @done (16-11-12 12:36)
- ☐ enable TLS and load certs
+ ✔ enable TLS and load certs @done (16-12-02 15:41)
+ ☐ Implement instrumentation and log middleware for platform.Service

--- a/cmd/sims/channel.go
+++ b/cmd/sims/channel.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"github.com/tapglue/snaas/core"
+	pErr "github.com/tapglue/snaas/error"
 	"github.com/tapglue/snaas/platform/sns"
 	"github.com/tapglue/snaas/service/app"
-	"github.com/tapglue/snaas/service/device"
 )
 
 type channelFunc func(*app.App, *message) error
@@ -12,8 +12,8 @@ type channelFunc func(*app.App, *message) error
 func channelPush(
 	deviceListUser core.DeviceListUserFunc,
 	deviceSync core.DeviceSyncEndpointFunc,
+	fetchActive core.PlatformFetchActiveFunc,
 	push sns.PushFunc,
-	pApps platformApps,
 ) channelFunc {
 	return func(currentApp *app.App, msg *message) error {
 		ds, err := deviceListUser(currentApp, msg.recipient)
@@ -25,31 +25,20 @@ func channelPush(
 		}
 
 		for _, d := range ds {
-			pa, err := platformAppForPlatform(pApps, currentApp, d.Platform)
+			p, err := fetchActive(currentApp, d.Platform)
 			if err != nil {
-				if isPlatformNotFound(err) {
+				if pErr.IsNotFound(err) {
 					continue
 				}
 				return err
 			}
 
-			d, err = deviceSync(currentApp, pa.ARN, d)
+			d, err = deviceSync(currentApp, p.ARN, d)
 			if err != nil {
 				return err
 			}
 
-			var p sns.Platform
-
-			switch d.Platform {
-			case device.PlatformAndroid:
-				p = sns.PlatformGCM
-			case device.PlatformIOS:
-				p = sns.PlatformAPNS
-			case device.PlatformIOSSandbox:
-				p = sns.PlatformAPNSSandbox
-			}
-
-			err = push(p, d.EndpointARN, pa.Scheme, msg.urn, msg.message)
+			err = push(d.Platform, d.EndpointARN, p.Scheme, msg.urn, msg.message)
 			if err != nil {
 				if sns.IsDeliveryFailure(err) {
 					return nil

--- a/cmd/sims/platform.go
+++ b/cmd/sims/platform.go
@@ -1,72 +1,17 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/tapglue/snaas/core"
 	"github.com/tapglue/snaas/service/app"
-	"github.com/tapglue/snaas/service/device"
 )
 
 var (
 	ErrInvalidNamespace = errors.New("namespace invalid")
-	ErrPlatformNotFound = errors.New("platform not found")
 )
-
-type platformApp struct {
-	ARN       string `json:"arn"`
-	Namespace string `json:"namespace"`
-	Scheme    string `json:"scheme"`
-	Platform  int    `json:"platform"`
-}
-
-type platformApps []*platformApp
-
-func (as *platformApps) Set(input string) error {
-	a := &platformApp{}
-	err := json.Unmarshal([]byte(input), a)
-	if err != nil {
-		return err
-	}
-
-	*as = append(*as, a)
-
-	return nil
-}
-
-func (as *platformApps) String() string {
-	return fmt.Sprintf("%d apps", len(*as))
-}
-
-func appForARN(
-	appFetch core.AppFetchFunc,
-	pApps platformApps,
-	pARN string,
-) (*app.App, error) {
-	var a *platformApp
-
-	for _, pa := range pApps {
-		if pa.ARN == pARN {
-			a = pa
-			break
-		}
-	}
-
-	if a == nil {
-		return nil, ErrPlatformNotFound
-	}
-
-	id, err := namespaceToID(a.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	return appFetch(id)
-}
 
 func appForNamespace(appFetch core.AppFetchFunc, ns string) (*app.App, error) {
 	id, err := namespaceToID(ns)
@@ -85,29 +30,4 @@ func namespaceToID(ns string) (uint64, error) {
 	}
 
 	return strconv.ParseUint(ps[1], 10, 64)
-}
-
-func isPlatformNotFound(err error) bool {
-	return err == ErrPlatformNotFound
-}
-
-func platformAppForPlatform(
-	pApps platformApps,
-	a *app.App,
-	p device.Platform,
-) (*platformApp, error) {
-	var pApp *platformApp
-
-	for _, pa := range pApps {
-		if pa.Namespace == a.Namespace() && device.Platform(pa.Platform) == p {
-			pApp = pa
-			break
-		}
-	}
-
-	if pApp == nil {
-		return nil, ErrPlatformNotFound
-	}
-
-	return pApp, nil
 }

--- a/core/device.go
+++ b/core/device.go
@@ -85,7 +85,7 @@ func DeviceListUser(devices device.Service) DeviceListUserFunc {
 		return devices.Query(currentApp.Namespace(), device.QueryOptions{
 			Deleted:  &defaultDeleted,
 			Disabled: &defaultDeleted,
-			Platforms: []device.Platform{
+			Platforms: []sns.Platform{
 				device.PlatformIOSSandbox,
 				device.PlatformIOS,
 				device.PlatformAndroid,
@@ -168,7 +168,7 @@ type DeviceUpdateFunc func(
 	currentApp *app.App,
 	origin Origin,
 	deviceID string,
-	platform device.Platform,
+	platform sns.Platform,
 	token string,
 	language string,
 ) error
@@ -179,13 +179,13 @@ func DeviceUpdate(devices device.Service) DeviceUpdateFunc {
 		currentApp *app.App,
 		origin Origin,
 		deviceID string,
-		platform device.Platform,
+		platform sns.Platform,
 		token string,
 		language string,
 	) error {
 		ds, err := devices.Query(currentApp.Namespace(), device.QueryOptions{
 			Deleted: &defaultDeleted,
-			Platforms: []device.Platform{
+			Platforms: []sns.Platform{
 				platform,
 			},
 			UserIDs: []uint64{

--- a/core/platform.go
+++ b/core/platform.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"fmt"
+
+	pErr "github.com/tapglue/snaas/error"
+	"github.com/tapglue/snaas/platform/pg"
+	"github.com/tapglue/snaas/platform/sns"
+	"github.com/tapglue/snaas/service/app"
+	"github.com/tapglue/snaas/service/platform"
+)
+
+var (
+	defaultActive = true
+)
+
+// PlatformCreateFunc stores the provided platform.
+type PlatformCreateFunc func(
+	currentApp *app.App,
+	p *platform.Platform,
+	cert, key string,
+) (*platform.Platform, error)
+
+// PlatformCreate stores the provided platform.
+func PlatformCreate(
+	platforms platform.Service,
+	createAPNS sns.AppCreateAPNSFunc,
+	createAPNSSandbox sns.AppCreateAPNSSandboxFunc,
+	createAndroid sns.AppCreateGCMFunc,
+) PlatformCreateFunc {
+	return func(
+		currentApp *app.App,
+		p *platform.Platform,
+		cert, key string,
+	) (*platform.Platform, error) {
+		arn := ""
+
+		fmt.Printf("\n%s\n%s\n%#v\n\n", cert, key, p)
+
+		switch p.Ecosystem {
+		case platform.Android:
+			var err error
+			arn, err = createAndroid(p.Name, key)
+			if err != nil {
+				return nil, err
+			}
+		case platform.IOS:
+			var err error
+			arn, err = createAPNS(p.Name, cert, key)
+			if err != nil {
+				return nil, err
+			}
+		case platform.IOSSandbox:
+			var err error
+			arn, err = createAPNSSandbox(p.Name, cert, key)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		p.AppID = currentApp.ID
+		p.ARN = arn
+
+		return platforms.Put(pg.MetaNamespace, p)
+	}
+}
+
+// PlatformFetchActiveFunc returns the active platform for the current app and the
+// given ecosystem.
+type PlatformFetchActiveFunc func(*app.App, sns.Platform) (*platform.Platform, error)
+
+// PlatformFetchActive returns the active platform for the current app and the
+// given ecosystem.
+func PlatformFetchActive(platforms platform.Service) PlatformFetchActiveFunc {
+	return func(
+		currentApp *app.App,
+		ecosystem sns.Platform,
+	) (*platform.Platform, error) {
+		ps, err := platforms.Query(pg.MetaNamespace, platform.QueryOptions{
+			Active: &defaultActive,
+			AppIDs: []uint64{
+				currentApp.ID,
+			},
+			Deleted: &defaultDeleted,
+			Ecosystems: []sns.Platform{
+				ecosystem,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(ps) != 1 {
+			return nil, pErr.Wrap(
+				pErr.ErrNotFound,
+				"no active platform found for %s",
+				sns.PlatformIdentifiers[ecosystem],
+			)
+		}
+
+		return ps[0], nil
+	}
+}
+
+// PlatformFetchByARNFunc returns the Platform for the given ARN.
+type PlatformFetchByARNFunc func(arn string) (*platform.Platform, error)
+
+// PlatformFetchByARN returns the Platform for the given ARN.
+func PlatformFetchByARN(platforms platform.Service) PlatformFetchByARNFunc {
+	return func(arn string) (*platform.Platform, error) {
+		ps, err := platforms.Query(pg.MetaNamespace, platform.QueryOptions{
+			ARNs: []string{
+				arn,
+			},
+			Deleted: &defaultDeleted,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(ps) != 1 {
+			return nil, pErr.Wrap(
+				pErr.ErrNotFound,
+				"no platform found for '%s'",
+				arn,
+			)
+		}
+
+		return ps[0], nil
+	}
+}

--- a/error/error.go
+++ b/error/error.go
@@ -1,0 +1,58 @@
+package error
+
+import (
+	"errors"
+	"fmt"
+)
+
+const errFmt = "%s: %s"
+
+// General-purpose errors.
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+// Platform errors.
+var (
+	ErrInvalidPlatform = errors.New("invalid platform")
+)
+
+// Error wrapper.
+type Error struct {
+	err error
+	msg string
+}
+
+func (e Error) Error() string {
+	return e.msg
+}
+
+// IsInvalidPlatform indicates if err is ErrInvalidPlatform.
+func IsInvalidPlatform(err error) bool {
+	return unwrapError(err) == ErrInvalidPlatform
+}
+
+// IsNotFound indicates if err is ErrNotFouund.
+func IsNotFound(err error) bool {
+	return unwrapError(err) == ErrNotFound
+}
+
+// Wrap constructs an Error with proper messaaging.
+func Wrap(err error, format string, args ...interface{}) error {
+	return &Error{
+		err: err,
+		msg: fmt.Sprintf(
+			errFmt,
+			err, fmt.Sprintf(format, args...),
+		),
+	}
+}
+
+func unwrapError(err error) error {
+	switch e := err.(type) {
+	case *Error:
+		return e.err
+	}
+
+	return err
+}

--- a/handler/http/device.go
+++ b/handler/http/device.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/tapglue/snaas/core"
-	"github.com/tapglue/snaas/service/device"
+	"github.com/tapglue/snaas/platform/sns"
 )
 
 // DeviceDelete removes a user's device.
@@ -58,15 +58,15 @@ func DeviceUpdate(fn core.DeviceUpdateFunc) Handler {
 
 type payloadDevice struct {
 	language string
-	platform device.Platform
+	platform sns.Platform
 	token    string
 }
 
 func (p *payloadDevice) UnmarshalJSON(raw []byte) error {
 	f := struct {
-		Language string          `json:"language"`
-		Platform device.Platform `json:"platform"`
-		Token    string          `json:"token"`
+		Language string       `json:"language"`
+		Platform sns.Platform `json:"platform"`
+		Token    string       `json:"token"`
 	}{}
 
 	err := json.Unmarshal(raw, &f)

--- a/handler/http/platform.go
+++ b/handler/http/platform.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/tapglue/snaas/core"
+	"github.com/tapglue/snaas/platform/sns"
+	"github.com/tapglue/snaas/service/platform"
+)
+
+// PlatformCreate stores the provided platform.
+func PlatformCreate(fn core.PlatformCreateFunc) Handler {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		var (
+			currentApp = appFromContext(ctx)
+			payload    = payloadPlatform{}
+		)
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			respondError(w, 0, wrapError(ErrBadRequest, err.Error()))
+			return
+		}
+
+		p, err := fn(currentApp, payload.platform, payload.cert, payload.key)
+		if err != nil {
+			respondError(w, 0, err)
+			return
+		}
+
+		respondJSON(w, http.StatusCreated, &payloadPlatform{platform: p})
+	}
+}
+
+type payloadPlatform struct {
+	cert, key string
+	platform  *platform.Platform
+}
+
+func (p *payloadPlatform) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Active    bool      `json:"active"`
+		ARN       string    `json:"arn"`
+		Deleted   bool      `json:"deleted"`
+		Ecosystem int       `json:"ecosystem"`
+		ID        string    `json:"id"`
+		Name      string    `json:"name"`
+		Scheme    string    `json:"scheme"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}{
+		Active:    p.platform.Active,
+		ARN:       p.platform.ARN,
+		Deleted:   p.platform.Deleted,
+		Ecosystem: int(p.platform.Ecosystem),
+		ID:        strconv.FormatUint(p.platform.ID, 10),
+		Name:      p.platform.Name,
+		Scheme:    p.platform.Scheme,
+		CreatedAt: p.platform.CreatedAt,
+		UpdatedAt: p.platform.UpdatedAt,
+	})
+}
+
+func (p *payloadPlatform) UnmarshalJSON(raw []byte) error {
+	f := struct {
+		Cert      string       `json:"cert"`
+		Ecosystem sns.Platform `json:"ecosystem"`
+		Key       string       `json:"key"`
+		Name      string       `json:"name"`
+		Scheme    string       `json:"scheme"`
+	}{}
+
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return err
+	}
+
+	p.cert = f.Cert
+	p.key = f.Key
+	p.platform = &platform.Platform{
+		Ecosystem: f.Ecosystem,
+		Name:      f.Name,
+		Scheme:    f.Scheme,
+	}
+
+	return nil
+}

--- a/service/device/device.go
+++ b/service/device/device.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/tapglue/snaas/platform/service"
+	"github.com/tapglue/snaas/platform/sns"
 )
 
 const (
@@ -16,9 +17,9 @@ const (
 
 // Platform supported for a Device.
 const (
-	PlatformIOSSandbox Platform = iota + 1
-	PlatformIOS
-	PlatformAndroid
+	PlatformIOS        = sns.PlatformAPNS
+	PlatformIOSSandbox = sns.PlatformAPNSSandbox
+	PlatformAndroid    = sns.PlatformGCM
 )
 
 // Device represents a physical device like mobile phone or tablet of a user.
@@ -29,7 +30,7 @@ type Device struct {
 	EndpointARN string
 	ID          uint64
 	Language    string
-	Platform    Platform
+	Platform    sns.Platform
 	Token       string
 	UserID      uint64
 	CreatedAt   time.Time
@@ -68,9 +69,6 @@ func (d *Device) Validate() error {
 // List is a collection of devices.
 type List []*Device
 
-// Platform of a device.
-type Platform uint8
-
 // QueryOptions is used to narrow-down user queries.
 type QueryOptions struct {
 	Deleted      *bool
@@ -78,7 +76,7 @@ type QueryOptions struct {
 	Disabled     *bool
 	EndpointARNs []string
 	IDs          []uint64
-	Platforms    []Platform
+	Platforms    []sns.Platform
 	UserIDs      []uint64
 }
 

--- a/service/device/helper_test.go
+++ b/service/device/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tapglue/snaas/platform/generate"
+	"github.com/tapglue/snaas/platform/sns"
 )
 
 type prepareFunc func(t *testing.T, namespace string) Service
@@ -149,7 +150,7 @@ func testServiceQuery(t *testing.T, p prepareFunc) {
 	}
 
 	ds, err = service.Query(namespace, QueryOptions{
-		Platforms: []Platform{
+		Platforms: []sns.Platform{
 			PlatformIOSSandbox,
 		},
 	})

--- a/service/platform/helper_test.go
+++ b/service/platform/helper_test.go
@@ -1,0 +1,151 @@
+package platform
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/tapglue/snaas/platform/generate"
+	"github.com/tapglue/snaas/platform/sns"
+)
+
+type prepareFunc func(t *testing.T, namespace string) Service
+
+func testServicePut(t *testing.T, p prepareFunc) {
+	var (
+		platform  = testPlatform()
+		namespace = "service_put"
+		service   = p(t, namespace)
+	)
+
+	created, err := service.Put(namespace, platform)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := service.Query(namespace, QueryOptions{
+		IDs: []uint64{
+			created.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(list), 1; have != want {
+		t.Fatalf("have %v, want %v", have, want)
+	}
+	if have, want := list[0], created; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	overwrite := testPlatform()
+	overwrite.CreatedAt = list[0].CreatedAt
+	overwrite.ID = list[0].ID
+
+	updated, err := service.Put(namespace, overwrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err = service.Query(namespace, QueryOptions{
+		IDs: []uint64{
+			updated.ID,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := list[0], updated; !reflect.DeepEqual(have, want) {
+		t.Errorf("have %v, want %v", have, want)
+	}
+}
+
+func testServiceQuery(t *testing.T, p prepareFunc) {
+	var (
+		activated = true
+		deleted   = true
+		input     = testPlatform()
+		namespace = "service_query"
+		service   = p(t, namespace)
+	)
+
+	ps, err := service.Query(namespace, QueryOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := len(ps), 0; have != want {
+		t.Errorf("have %v, want %v", have, want)
+	}
+
+	input.Active = true
+
+	created, err := service.Put(namespace, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, p := range testList() {
+		_, err := service.Put(namespace, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := map[*QueryOptions]int{
+		&QueryOptions{}:                                24,
+		&QueryOptions{Active: &activated}:              1,
+		&QueryOptions{ARNs: []string{created.ARN}}:     1,
+		&QueryOptions{AppIDs: []uint64{created.AppID}}: 1,
+		&QueryOptions{Deleted: &deleted}:               5,
+		&QueryOptions{Ecosystems: []sns.Platform{IOS}}: 11,
+		&QueryOptions{IDs: []uint64{created.ID}}:       1,
+	}
+	for opts, want := range cases {
+		list, err := service.Query(namespace, *opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if have := len(list); have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}
+
+func testList() List {
+	ps := List{}
+
+	for i := 0; i < 7; i++ {
+		ps = append(ps, testPlatform())
+	}
+
+	for i := 0; i < 5; i++ {
+		p := testPlatform()
+		p.Deleted = true
+
+		ps = append(ps, p)
+	}
+
+	for i := 0; i < 11; i++ {
+		p := testPlatform()
+		p.Ecosystem = IOS
+
+		ps = append(ps, p)
+	}
+
+	return ps
+}
+
+func testPlatform() *Platform {
+	return &Platform{
+		Active:    false,
+		AppID:     uint64(rand.Int63()),
+		ARN:       generate.RandomStringSafe(24),
+		Ecosystem: Android,
+		Name:      generate.RandomStringSafe(8),
+		Scheme:    generate.RandomStringSafe(4),
+	}
+}

--- a/service/platform/platform.go
+++ b/service/platform/platform.go
@@ -1,0 +1,84 @@
+package platform
+
+import (
+	"fmt"
+	"time"
+
+	pErr "github.com/tapglue/snaas/error"
+	"github.com/tapglue/snaas/platform/service"
+	"github.com/tapglue/snaas/platform/sns"
+)
+
+// Ecosystem supported for a Platform.
+const (
+	IOS        = sns.PlatformAPNS
+	IOSSandbox = sns.PlatformAPNSSandbox
+	Android    = sns.PlatformGCM
+)
+
+// Platform represents an ecosystem like Android or iOS for user device management.
+type Platform struct {
+	Active    bool
+	AppID     uint64
+	ARN       string
+	Deleted   bool
+	Ecosystem sns.Platform
+	ID        uint64
+	Name      string
+	Scheme    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Validate check for semantic correctness.
+func (p *Platform) Validate() error {
+	if p.ARN == "" {
+		return pErr.Wrap(pErr.ErrInvalidPlatform, "ARN must be set")
+	}
+
+	if p.Ecosystem == 0 {
+		return pErr.Wrap(pErr.ErrInvalidPlatform, "Ecosystem must be set")
+	}
+
+	if p.Ecosystem > Android {
+		return pErr.Wrap(pErr.ErrInvalidPlatform, "Ecosystem '%d' not supported", p.Ecosystem)
+	}
+
+	if p.Name == "" {
+		return pErr.Wrap(pErr.ErrInvalidPlatform, "Name must be set")
+	}
+
+	if p.Scheme == "" {
+		return pErr.Wrap(pErr.ErrInvalidPlatform, "Scheme must be set")
+	}
+
+	return nil
+}
+
+// List is a collection of Platforms.
+type List []*Platform
+
+// QueryOptions to narrow-down platform queries.
+type QueryOptions struct {
+	Active     *bool
+	ARNs       []string
+	AppIDs     []uint64
+	Deleted    *bool
+	Ecosystems []sns.Platform
+	IDs        []uint64
+}
+
+// Service for platform interactions.
+type Service interface {
+	service.Lifecycle
+
+	Put(namespace string, platform *Platform) (*Platform, error)
+	Query(namespace string, opts QueryOptions) (List, error)
+}
+
+// ServiceMiddleware is a chainable behaviour modifier for Service.
+type ServiceMiddleware func(Service) Service
+
+func flakeNamespace(ns string) string {
+	return fmt.Sprintf("%s_%s", ns, "platforms")
+}

--- a/service/platform/platform_test.go
+++ b/service/platform/platform_test.go
@@ -1,0 +1,26 @@
+package platform
+
+import (
+	"testing"
+
+	pErr "github.com/tapglue/snaas/error"
+)
+
+func TestValidate(t *testing.T) {
+	var (
+		p  = testPlatform()
+		ps = List{
+			{},                                                 // Missing ARN
+			{ARN: p.ARN},                                       // Missing Ecosystem
+			{ARN: p.ARN, Ecosystem: 4},                         // Unsupported Ecosystem
+			{ARN: p.ARN, Ecosystem: p.Ecosystem},               // Missing Name
+			{ARN: p.ARN, Ecosystem: p.Ecosystem, Name: p.Name}, // Missing Scheme
+		}
+	)
+
+	for _, p := range ps {
+		if have, want := p.Validate(), pErr.ErrInvalidPlatform; !pErr.IsInvalidPlatform(have) {
+			t.Errorf("have %v, want %v", have, want)
+		}
+	}
+}

--- a/service/platform/postgres.go
+++ b/service/platform/postgres.go
@@ -1,0 +1,375 @@
+package platform
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/tapglue/snaas/platform/flake"
+	"github.com/tapglue/snaas/platform/pg"
+)
+
+const (
+	pgInsertPlatform = `INSERT INTO
+		%s.platforms(active, app_id, arn, deleted, ecosystem, id, name, scheme, created_at, updated_at)
+		VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+	pgUpdatePlatform = `
+		UPDATE
+			%s.platforms
+		SET
+			active = $2,
+			app_id = $3,
+			arn = $4,
+			deleted = $5,
+			ecosystem = $6,
+			name = $7,
+			scheme = $8,
+			updated_at = $9
+		WHERE
+			id = $1`
+
+	pgClauseActive     = `active = ?`
+	pgClauseAppIDs     = `app_id IN (?)`
+	pgClauseARNs       = `arn IN (?)`
+	pgClauseDeleted    = `deleted = ?`
+	pgClauseEcosystems = `ecosystem IN (?)`
+	pgClauseIDs        = `id IN (?)`
+
+	pgListPlatforms = `
+		SELECT
+			active, app_id, arn, deleted, ecosystem, id, name, scheme, created_at, updated_at
+		FROM
+			%s.platforms
+		%s`
+
+	pgOrderCreatedAt = `ORDER BY created_at DESC`
+
+	pgCreateSchema = `CREATE SCHEMA IF NOT EXISTS %s`
+	pgCreateTable  = `CREATE TABLE IF NOT EXISTS %s.platforms(
+		active BOOL DEFAULT false,
+		app_id BIGINT NOT NULL,
+		arn TEXT NOT NULL,
+		deleted BOOL DEFAULT false,
+		ecosystem INT NOT NULL,
+		id BIGINT NOT NULL UNIQUE,
+		name CITEXT NOT NULL UNIQUE,
+		scheme TEXT NOT NULL,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL
+	)`
+	pgDropTable = `DROP TABLE IF EXISTS %s.platforms`
+)
+
+type pgService struct {
+	db *sqlx.DB
+}
+
+// PostgresService returns a Postgres based Service implementation.
+func PostgresService(db *sqlx.DB) Service {
+	return &pgService{
+		db: db,
+	}
+}
+
+func (s *pgService) Put(ns string, p *Platform) (*Platform, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+
+	if p.ID == 0 {
+		return s.insert(ns, p)
+	}
+
+	return s.update(ns, p)
+}
+
+func (s *pgService) Query(ns string, opts QueryOptions) (List, error) {
+	clauses, params, err := convertOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ps, err := s.listPlatforms(ns, clauses, params...)
+	if err != nil {
+		if pg.IsRelationNotFound(pg.WrapError(err)) {
+			if err := s.Setup(ns); err != nil {
+				return nil, err
+			}
+		}
+
+		ps, err = s.listPlatforms(ns, clauses, params...)
+	}
+
+	return ps, err
+}
+
+func (s *pgService) Setup(ns string) error {
+	qs := []string{
+		fmt.Sprintf(pgCreateSchema, ns),
+		fmt.Sprintf(pgCreateTable, ns),
+	}
+
+	for _, q := range qs {
+		_, err := s.db.Exec(q)
+		if err != nil {
+			return fmt.Errorf("setup (%s): %s", q, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *pgService) Teardown(ns string) error {
+	qs := []string{
+		fmt.Sprintf(pgDropTable, ns),
+	}
+
+	for _, q := range qs {
+		_, err := s.db.Exec(q)
+		if err != nil {
+			return fmt.Errorf("teardown '%s': %s", q, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *pgService) insert(ns string, p *Platform) (*Platform, error) {
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = time.Now().UTC()
+	}
+
+	ts, err := time.Parse(pg.TimeFormat, p.CreatedAt.UTC().Format(pg.TimeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	p.CreatedAt = ts
+	p.UpdatedAt = ts
+
+	id, err := flake.NextID(flakeNamespace(ns))
+	if err != nil {
+		return nil, err
+	}
+
+	p.ID = id
+
+	var (
+		params = []interface{}{
+			p.Active,
+			p.AppID,
+			p.ARN,
+			p.Deleted,
+			p.Ecosystem,
+			p.ID,
+			p.Name,
+			p.Scheme,
+			p.CreatedAt,
+			p.UpdatedAt,
+		}
+		query = fmt.Sprintf(pgInsertPlatform, ns)
+	)
+
+	_, err = s.db.Exec(query, params...)
+	if err != nil {
+		if pg.IsRelationNotFound(pg.WrapError(err)) {
+			if err := s.Setup(ns); err != nil {
+				return nil, err
+			}
+
+			_, err = s.db.Exec(query, params...)
+		}
+	}
+
+	return p, err
+}
+
+func (s *pgService) listPlatforms(
+	ns string,
+	clauses []string,
+	params ...interface{},
+) (List, error) {
+	c := strings.Join(clauses, "\nAND")
+
+	if len(clauses) > 0 {
+		c = fmt.Sprintf("WHERE %s", c)
+	}
+
+	query := strings.Join([]string{
+		fmt.Sprintf(pgListPlatforms, ns, c),
+		pgOrderCreatedAt,
+	}, "\n")
+
+	query = sqlx.Rebind(sqlx.DOLLAR, query)
+
+	rows, err := s.db.Query(query, params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ps := List{}
+
+	for rows.Next() {
+		p := &Platform{}
+
+		err := rows.Scan(
+			&p.Active,
+			&p.AppID,
+			&p.ARN,
+			&p.Deleted,
+			&p.Ecosystem,
+			&p.ID,
+			&p.Name,
+			&p.Scheme,
+			&p.CreatedAt,
+			&p.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		p.CreatedAt = p.CreatedAt.UTC()
+		p.UpdatedAt = p.UpdatedAt.UTC()
+
+		ps = append(ps, p)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}
+
+func (s *pgService) update(ns string, p *Platform) (*Platform, error) {
+	now, err := time.Parse(pg.TimeFormat, time.Now().UTC().Format(pg.TimeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	p.UpdatedAt = now
+
+	var (
+		params = []interface{}{
+			p.ID,
+			p.Active,
+			p.AppID,
+			p.ARN,
+			p.Deleted,
+			p.Ecosystem,
+			p.Name,
+			p.Scheme,
+			p.UpdatedAt,
+		}
+		query = fmt.Sprintf(pgUpdatePlatform, ns)
+	)
+
+	_, err = s.db.Exec(query, params...)
+	if err != nil {
+		if pg.IsRelationNotFound(pg.WrapError(err)) {
+			if err := s.Setup(ns); err != nil {
+				return nil, err
+			}
+
+			_, err = s.db.Exec(query, params...)
+		}
+	}
+
+	return p, err
+}
+
+func convertOpts(opts QueryOptions) ([]string, []interface{}, error) {
+	var (
+		clauses = []string{}
+		params  = []interface{}{}
+	)
+
+	if opts.Active != nil {
+		clause, _, err := sqlx.In(pgClauseActive, []interface{}{*opts.Active})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, *opts.Active)
+	}
+
+	if len(opts.AppIDs) > 0 {
+		ps := []interface{}{}
+
+		for _, id := range opts.AppIDs {
+			ps = append(ps, id)
+		}
+
+		clause, _, err := sqlx.In(pgClauseAppIDs, ps)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if len(opts.ARNs) > 0 {
+		ps := []interface{}{}
+
+		for _, arn := range opts.ARNs {
+			ps = append(ps, arn)
+		}
+
+		clause, _, err := sqlx.In(pgClauseARNs, ps)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if opts.Deleted != nil {
+		clause, _, err := sqlx.In(pgClauseDeleted, []interface{}{*opts.Deleted})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, *opts.Deleted)
+	}
+
+	if len(opts.Ecosystems) > 0 {
+		ps := []interface{}{}
+
+		for _, e := range opts.Ecosystems {
+			ps = append(ps, e)
+		}
+
+		clause, _, err := sqlx.In(pgClauseEcosystems, ps)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if len(opts.IDs) > 0 {
+		ps := []interface{}{}
+
+		for _, id := range opts.IDs {
+			ps = append(ps, id)
+		}
+
+		clause, _, err := sqlx.In(pgClauseIDs, ps)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	return clauses, params, nil
+}

--- a/service/platform/postgres_test.go
+++ b/service/platform/postgres_test.go
@@ -1,0 +1,54 @@
+// +build integration
+
+package platform
+
+import (
+	"flag"
+	"fmt"
+	"os/user"
+
+	"github.com/tapglue/snaas/platform/pg"
+
+	"github.com/jmoiron/sqlx"
+
+	"testing"
+)
+
+var pgTestURL string
+
+func TestPostgresPut(t *testing.T) {
+	testServicePut(t, preparePostgres)
+}
+
+func TestPostgresQuery(t *testing.T) {
+	testServiceQuery(t, preparePostgres)
+}
+
+func preparePostgres(t *testing.T, namespace string) Service {
+	db, err := sqlx.Connect("postgres", pgTestURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := PostgresService(db)
+
+	if err := s.Teardown(namespace); err != nil {
+		t.Fatal(err)
+	}
+
+	return s
+}
+
+func init() {
+	u, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	d := fmt.Sprintf(pg.URLTest, u.Username)
+
+	url := flag.String("postgres.url", d, "Postgres test connection URL")
+	flag.Parse()
+
+	pgTestURL = *url
+}


### PR DESCRIPTION
Which are used as the book-keeping glue between Apps and the SNS entity used for notification routing.

* implement platform service
* implement platform create handler (not mounted)
* implement platform create and fetch by ARN or active per app
* add first centralised errors