### PR TITLE
Raise tag limit for objects

### DIFF
--- a/service/object/object.go
+++ b/service/object/object.go
@@ -175,7 +175,7 @@ func (o *Object) Validate() error {
 		)
 	}
 
-	if len(o.Tags) > 5 {
+	if len(o.Tags) > 25 {
 		return wrapError(ErrInvalidObject, "too many tags")
 	}
 

--- a/service/object/object_test.go
+++ b/service/object/object_test.go
@@ -79,25 +79,6 @@ func TestObjectValidate(t *testing.T) {
 			Type:       "post",
 			Visibility: VisibilityConnection,
 		},
-		// Too many Tags
-		{
-			OwnerID: 123,
-			Tags: []string{
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-				"tag",
-			},
-			Type:       "post",
-			Visibility: VisibilityConnection,
-		},
 		// Missing Type
 		{
 			OwnerID:    123,


### PR DESCRIPTION
With the increased use of tags esp. for semantic distinction of posts the current limit turns out to be not sufficient when semantic tags are mixed with user input. There might be an opportunity to split those apart to avoid unnecessary side-effects.