### PR TITLE
Android notification structure

### DIFF
--- a/doc/notifications-structure-android.md
+++ b/doc/notifications-structure-android.md
@@ -4,7 +4,10 @@ The current structure of the notification payload on android does not allow for 
 
 ## Proposed solution
 
+Replace the notification message with a data message. Documentation on both types can be found [here](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages)
+
 1. Add the data from the `notification` object to the `data` object.
+2. Put the `data` object on the top level
 2. Remove the `notification` object.
 
 The names of the fields in the `notification` object could be the same in the `data` object. This way the client has to manually handle their notifications, which gives it the liberty to customise the design.

--- a/doc/notifications-structure-android.md
+++ b/doc/notifications-structure-android.md
@@ -1,0 +1,13 @@
+# Android notification structure
+
+The current structure of the notification payload on android does not allow for customization on the client side. When a `notification` object is present the only customization possible is the notification icon and the primary color.
+
+## Proposed solution
+
+1. Add the data from the `notification` object to the `data` object.
+2. Remove the `notification` object.
+
+The names of the fields in the `notification` object could be the same in the `data` object. This way the client has to manually handle their notifications, which gives it the liberty to customize the design.
+
+This solution would also be more extensible than the previous solution as it allows for custom fields (i.e. user avatars etc).
+

--- a/doc/notifications-structure-android.md
+++ b/doc/notifications-structure-android.md
@@ -1,13 +1,13 @@
 # Android notification structure
 
-The current structure of the notification payload on android does not allow for customization on the client side. When a `notification` object is present the only customization possible is the notification icon and the primary color.
+The current structure of the notification payload on android does not allow for customisation on the client side. When a `notification` object is present the only customisation possible is the notification icon and the primary color.
 
 ## Proposed solution
 
 1. Add the data from the `notification` object to the `data` object.
 2. Remove the `notification` object.
 
-The names of the fields in the `notification` object could be the same in the `data` object. This way the client has to manually handle their notifications, which gives it the liberty to customize the design.
+The names of the fields in the `notification` object could be the same in the `data` object. This way the client has to manually handle their notifications, which gives it the liberty to customise the design.
 
 This solution would also be more extensible than the previous solution as it allows for custom fields (i.e. user avatars etc).
 

--- a/platform/sns/sns.go
+++ b/platform/sns/sns.go
@@ -43,7 +43,7 @@ const (
 	fmtURN         = `%s://%s`
 	msgAPNS        = `{"APNS": "{\"aps\": {\"alert\": \"%s\"}, \"urn\":\"%s\"}" }`
 	msgAPNSSandbox = `{"APNS_SANDBOX": "{\"aps\": {\"alert\": \"%s\"}, \"urn\":\"%s\"}" }`
-	msgGCM         = `{"GCM": "{\"notification\": {\"title\": \"%s\", \"data\": {\"urn\": \"%s\"}} }"}`
+	msgGCM         = `{"GCM": "{\"data\": {\"title\": \"Social\", \"body\": \"%s\", \"urn\": \"%s\"} }" }`
 )
 
 // PlatformIdentifiers helps to map Platfrom to human-readable strings.


### PR DESCRIPTION
# Android notification structure

The current structure of the notification payload on android does not allow for customisation on the client side. When a `notification` object is present the only customisation possible is the notification icon and the primary color.

## Proposed solution

Replace the notification message with a data message. Documentation on both types can be found [here](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages)

1. Add the data from the `notification` object to the `data` object.
2. Put the `data` object on the top level
2. Remove the `notification` object.

The names of the fields in the `notification` object could be the same in the `data` object. This way the client has to manually handle their notifications, which gives it the liberty to customise the design.

This solution would also be more extensible than the previous solution as it allows for custom fields (i.e. user avatars etc).