### PR TITLE
Fix double device registration

### DIFF
--- a/core/device.go
+++ b/core/device.go
@@ -198,6 +198,7 @@ func DeviceUpdate(devices device.Service) DeviceUpdateFunc {
 		token string,
 		language string,
 	) error {
+		// Get user devices.
 		ds, err := devices.Query(currentApp.Namespace(), device.QueryOptions{
 			Deleted: &defaultDeleted,
 			Platforms: []sns.Platform{
@@ -210,6 +211,19 @@ func DeviceUpdate(devices device.Service) DeviceUpdateFunc {
 		if err != nil {
 			return err
 		}
+
+		// Check if there is a device with that token.
+		ts, err := devices.Query(currentApp.Namespace(), device.QueryOptions{
+			Deleted: &defaultDeleted,
+			Tokens: []string{
+				token,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		ds = append(ds, ts...)
 
 		d := &device.Device{}
 

--- a/service/device/device.go
+++ b/service/device/device.go
@@ -77,6 +77,7 @@ type QueryOptions struct {
 	EndpointARNs []string
 	IDs          []uint64
 	Platforms    []sns.Platform
+	Tokens       []string
 	UserIDs      []uint64
 }
 

--- a/service/device/helper_test.go
+++ b/service/device/helper_test.go
@@ -88,91 +88,26 @@ func testServiceQuery(t *testing.T, p prepareFunc) {
 		}
 	}
 
-	ds, err = service.Query(namespace, QueryOptions{
-		Deleted: &deleted,
-	})
-	if err != nil {
-		t.Fatal(err)
+	cases := map[*QueryOptions]int{
+		&QueryOptions{Deleted: &deleted}:                             5,
+		&QueryOptions{DeviceIDs: []string{created.DeviceID}}:         1,
+		&QueryOptions{Disabled: &deleted}:                            7,
+		&QueryOptions{EndpointARNs: []string{created.EndpointARN}}:   1,
+		&QueryOptions{IDs: []uint64{created.ID}}:                     1,
+		&QueryOptions{Platforms: []sns.Platform{PlatformIOSSandbox}}: 13,
+		&QueryOptions{Tokens: []string{created.Token}}:               1,
+		&QueryOptions{UserIDs: []uint64{created.UserID}}:             1,
 	}
 
-	if have, want := len(ds), 5; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
+	for opts, want := range cases {
+		list, err := service.Query(namespace, *opts)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	ds, err = service.Query(namespace, QueryOptions{
-		DeviceIDs: []string{
-			created.DeviceID,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 1; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	ds, err = service.Query(namespace, QueryOptions{
-		Disabled: &deleted,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 7; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	ds, err = service.Query(namespace, QueryOptions{
-		EndpointARNs: []string{
-			created.EndpointARN,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 1; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	ds, err = service.Query(namespace, QueryOptions{
-		IDs: []uint64{
-			created.ID,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 1; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	ds, err = service.Query(namespace, QueryOptions{
-		Platforms: []sns.Platform{
-			PlatformIOSSandbox,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 13; have != want {
-		t.Errorf("have %v, want %v", have, want)
-	}
-
-	ds, err = service.Query(namespace, QueryOptions{
-		UserIDs: []uint64{
-			created.UserID,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if have, want := len(ds), 1; have != want {
-		t.Errorf("have %v, want %v", have, want)
+		if have := len(list); have != want {
+			t.Errorf("have %v, want %v", have, want)
+		}
 	}
 }
 

--- a/service/device/postgres.go
+++ b/service/device/postgres.go
@@ -42,6 +42,7 @@ const (
 	pgClauseEndpointARNs = `endpoint_arn IN (?)`
 	pgClauseIDs          = `id IN (?)`
 	pgClausePlatforms    = `platform IN (?)`
+	pgClauseTokens       = `token IN (?)`
 	pgClauseUserIDs      = `user_id IN (?)`
 
 	pgOrderCreatedAt = `ORDER BY created_at DESC`
@@ -374,6 +375,22 @@ func convertOpts(opts QueryOptions) ([]string, []interface{}, error) {
 		}
 
 		clause, _, err := sqlx.In(pgClausePlatforms, ps)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		clauses = append(clauses, clause)
+		params = append(params, ps...)
+	}
+
+	if len(opts.Tokens) > 0 {
+		ps := []interface{}{}
+
+		for _, p := range opts.Tokens {
+			ps = append(ps, p)
+		}
+
+		clause, _, err := sqlx.In(pgClauseTokens, ps)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
In case the same device is registered with a new user it can lead to receiving push notifications not targeted at the user. To alleviate this we check if their is a device with the same token regardless which user it belongs to.