### PR TITLE
Add reaction state to posts

### DIFF
--- a/core/feed.go
+++ b/core/feed.go
@@ -261,6 +261,11 @@ func FeedEvents(
 			return nil, err
 		}
 
+		err = enrichHasReacted(reactions, currentApp, origin, ps)
+		if err != nil {
+			return nil, err
+		}
+
 		err = enrichIsLiked(events, currentApp, origin, ps)
 		if err != nil {
 			return nil, err
@@ -382,6 +387,11 @@ func FeedNews(
 			return nil, err
 		}
 
+		err = enrichHasReacted(reactions, currentApp, origin, ps)
+		if err != nil {
+			return nil, err
+		}
+
 		err = enrichIsLiked(events, currentApp, origin, ps)
 		if err != nil {
 			return nil, err
@@ -435,6 +445,11 @@ func FeedNews(
 		}
 
 		err = enrichCounts(events, objects, reactions, currentApp, ps)
+		if err != nil {
+			return nil, err
+		}
+
+		err = enrichHasReacted(reactions, currentApp, origin, ps)
 		if err != nil {
 			return nil, err
 		}
@@ -605,6 +620,11 @@ func FeedPosts(
 		}
 
 		err = enrichCounts(events, objects, reactions, currentApp, ps)
+		if err != nil {
+			return nil, err
+		}
+
+		err = enrichHasReacted(reactions, currentApp, origin, ps)
 		if err != nil {
 			return nil, err
 		}

--- a/core/like.go
+++ b/core/like.go
@@ -314,6 +314,11 @@ func LikesUser(
 		}
 
 		if !r.isSelf {
+			err = enrichHasReacted(reactions, currentApp, origin, ps)
+			if err != nil {
+				return nil, err
+			}
+
 			err := enrichIsLiked(events, currentApp, origin, ps)
 			if err != nil {
 				return nil, err

--- a/handler/http/post.go
+++ b/handler/http/post.go
@@ -354,6 +354,7 @@ func (p *payloadPost) MarshalJSON() ([]byte, error) {
 		Attachments  []*payloadAttachment `json:"attachments"`
 		Counts       postCounts           `json:"counts"`
 		CreatedAt    time.Time            `json:"created_at,omitempty"`
+		HasReacted   core.HasReacted      `json:"has_reacted"`
 		ID           string               `json:"id"`
 		IsLiked      bool                 `json:"is_liked"`
 		Restrictions *object.Restrictions `json:"restrictions,omitempty"`
@@ -376,6 +377,7 @@ func (p *payloadPost) MarshalJSON() ([]byte, error) {
 			},
 		},
 		CreatedAt:    p.post.CreatedAt,
+		HasReacted:   p.post.HasReacted,
 		ID:           strconv.FormatUint(p.post.ID, 10),
 		IsLiked:      p.post.IsLiked,
 		Restrictions: p.post.Restrictions,


### PR DESCRIPTION
For client to reason if the user has reacted to a post with one of the available reactions we extend the Post representation with the `has_reacted` field which has a boolean for every of the possible
reactions.

```
{
  ...
  "has_reacted": {
    "live": false,
    "love": false,
    "haha": true,
    ...
  },
  ...
}
```