### PR TITLE
Implement reaction multi count

### DIFF
--- a/core/feed.go
+++ b/core/feed.go
@@ -1286,7 +1286,7 @@ func sourceReactions(
 				Type: fmt.Sprintf(
 					reactionEventFmt,
 					event.TypeReaction,
-					reaction.TypeToIdenitifier[r.Type],
+					reaction.TypeToIdentifier[r.Type],
 				),
 				UserID:     r.OwnerID,
 				Visibility: event.VisibilityPrivate,

--- a/core/reaction.go
+++ b/core/reaction.go
@@ -212,13 +212,3 @@ type ReactionFeed struct {
 	PostMap   PostMap
 	UserMap   user.Map
 }
-
-// ReactionCounts bundles all Reaction counts by type.
-type ReactionCounts struct {
-	Angry uint
-	Haha  uint
-	Like  uint
-	Love  uint
-	Sad   uint
-	Wow   uint
-}

--- a/handler/http/post.go
+++ b/handler/http/post.go
@@ -451,12 +451,12 @@ type postCounts struct {
 }
 
 type reactionCounts struct {
-	Angry uint `json:"angry"`
-	Haha  uint `json:"haha"`
-	Like  uint `json:"like"`
-	Love  uint `json:"love"`
-	Sad   uint `json:"sad"`
-	Wow   uint `json:"wow"`
+	Angry uint64 `json:"angry"`
+	Haha  uint64 `json:"haha"`
+	Like  uint64 `json:"like"`
+	Love  uint64 `json:"love"`
+	Sad   uint64 `json:"sad"`
+	Wow   uint64 `json:"wow"`
 }
 
 type postFields struct {

--- a/service/reaction/cache.go
+++ b/service/reaction/cache.go
@@ -50,6 +50,10 @@ func (s *cacheService) Count(ns string, opts QueryOptions) (uint, error) {
 	return aCount, err
 }
 
+func (s *cacheService) CountMulti(ns string, opts QueryOptions) (CountsMap, error) {
+	return nil, fmt.Errorf("cacheService.CountMulti not implemented")
+}
+
 func (s *cacheService) Put(ns string, input *Reaction) (*Reaction, error) {
 	key := cacheCountKey(QueryOptions{
 		ObjectIDs: []uint64{
@@ -104,7 +108,7 @@ func cacheCountKey(opts QueryOptions) string {
 	}
 
 	if len(opts.Types) == 1 {
-		ps = append(ps, TypeToIdenitifier[opts.Types[0]])
+		ps = append(ps, TypeToIdentifier[opts.Types[0]])
 	}
 
 	if len(opts.ObjectIDs) == 1 {

--- a/service/reaction/helper_test.go
+++ b/service/reaction/helper_test.go
@@ -51,6 +51,54 @@ func testServiceCount(p prepareFunc, t *testing.T) {
 	}
 }
 
+func testServiceCountMulti(p prepareFunc, t *testing.T) {
+	var (
+		objectIDs = []uint64{
+			uint64(rand.Int63()),
+			uint64(rand.Int63()),
+			uint64(rand.Int63()),
+		}
+		ownerID   = uint64(rand.Int63())
+		namespace = "service_count_multi"
+		service   = p(t, namespace)
+	)
+
+	for _, oid := range objectIDs {
+		for _, r := range testList(oid, ownerID) {
+			r.ObjectID = oid
+
+			_, err := service.Put(namespace, r)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	want := CountsMap{}
+
+	for _, oid := range objectIDs {
+		want[oid] = Counts{
+			Angry: 5,
+			Haha:  3,
+			Like:  21,
+			Love:  9,
+			Sad:   1,
+			Wow:   7,
+		}
+	}
+
+	have, err := service.CountMulti(namespace, QueryOptions{
+		ObjectIDs: objectIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(have, want) {
+		t.Errorf("\nhave %v\nwant %v", have, want)
+	}
+}
+
 func testServicePut(p prepareFunc, t *testing.T) {
 	var (
 		deleted   = true

--- a/service/reaction/instrumentation.go
+++ b/service/reaction/instrumentation.go
@@ -50,6 +50,14 @@ func (s *instrumentService) Count(
 	return s.next.Count(ns, opts)
 }
 
+func (s *instrumentService) CountMulti(ns string, opts QueryOptions) (m CountsMap, err error) {
+	defer func(begin time.Time) {
+		s.track("CountMulti", ns, begin, err)
+	}(time.Now())
+
+	return s.next.CountMulti(ns, opts)
+}
+
 func (s *instrumentService) Put(
 	ns string,
 	input *Reaction,
@@ -132,6 +140,8 @@ type instrumentSource struct {
 	store        string
 }
 
+// InstrumentSourceMiddleware observes key apsects of Source operations and exposes
+// Prometheus metrics.
 func InstrumentSourceMiddleware(
 	component, store string,
 	errCount kitmetrics.Counter,

--- a/service/reaction/logging.go
+++ b/service/reaction/logging.go
@@ -134,6 +134,26 @@ func (s *logService) Count(ns string, opts QueryOptions) (count uint, err error)
 	return s.next.Count(ns, opts)
 }
 
+func (s *logService) CountMulti(ns string, opts QueryOptions) (m CountsMap, err error) {
+	defer func(begin time.Time) {
+		ps := []interface{}{
+			"duration_ns", time.Since(begin).Nanoseconds(),
+			"keys_count", len(m),
+			"method", "CountMulti",
+			"namespace", ns,
+			"opts", opts,
+		}
+
+		if err != nil {
+			ps = append(ps, "err", err)
+		}
+
+		_ = s.logger.Log(ps...)
+	}(time.Now())
+
+	return s.next.CountMulti(ns, opts)
+}
+
 func (s *logService) Put(ns string, input *Reaction) (output *Reaction, err error) {
 	defer func(begin time.Time) {
 		ps := []interface{}{

--- a/service/reaction/mem.go
+++ b/service/reaction/mem.go
@@ -26,6 +26,45 @@ func (s *memService) Count(ns string, opts QueryOptions) (uint, error) {
 	return uint(len(filterList(s.reactions[ns].ToList(), opts))), nil
 }
 
+func (s *memService) CountMulti(ns string, opts QueryOptions) (CountsMap, error) {
+	if err := s.Setup(ns); err != nil {
+		return nil, err
+	}
+
+	countsMap := CountsMap{}
+
+	for _, oid := range opts.ObjectIDs {
+		counts := Counts{}
+
+		for _, r := range s.reactions[ns] {
+			if r.Deleted {
+				continue
+			}
+
+			if r.ObjectID == oid {
+				switch r.Type {
+				case TypeAngry:
+					counts.Angry++
+				case TypeHaha:
+					counts.Haha++
+				case TypeLike:
+					counts.Like++
+				case TypeLove:
+					counts.Love++
+				case TypeSad:
+					counts.Sad++
+				case TypeWow:
+					counts.Wow++
+				}
+			}
+		}
+
+		countsMap[oid] = counts
+	}
+
+	return countsMap, nil
+}
+
 func (s *memService) Put(ns string, input *Reaction) (*Reaction, error) {
 	if err := s.Setup(ns); err != nil {
 		return nil, err

--- a/service/reaction/mem_test.go
+++ b/service/reaction/mem_test.go
@@ -6,6 +6,10 @@ func TestMemCount(t *testing.T) {
 	testServiceCount(prepareMem, t)
 }
 
+func TestMemCountMulti(t *testing.T) {
+	testServiceCountMulti(prepareMem, t)
+}
+
 func TestMemPut(t *testing.T) {
 	testServicePut(prepareMem, t)
 }

--- a/service/reaction/postgres_test.go
+++ b/service/reaction/postgres_test.go
@@ -18,6 +18,10 @@ func TestPostgresCount(t *testing.T) {
 	testServiceCount(preparePostgres, t)
 }
 
+func TestPostgresCountMulti(t *testing.T) {
+	testServiceCountMulti(preparePostgres, t)
+}
+
 func TestPostgresPut(t *testing.T) {
 	testServicePut(preparePostgres, t)
 }

--- a/service/reaction/reaction.go
+++ b/service/reaction/reaction.go
@@ -20,7 +20,9 @@ const (
 	TypeAngry
 )
 
-var TypeToIdenitifier = map[Type]string{
+// TypeToIdentifier is the lookup of a reaction type to human readable
+// idenitfier.
+var TypeToIdentifier = map[Type]string{
 	TypeLike:  "like",
 	TypeLove:  "love",
 	TypeHaha:  "haha",
@@ -33,6 +35,19 @@ var TypeToIdenitifier = map[Type]string{
 type Consumer interface {
 	Consume() (*StateChange, error)
 }
+
+// Counts bundles all Reaction counts by type.
+type Counts struct {
+	Angry uint64
+	Haha  uint64
+	Like  uint64
+	Love  uint64
+	Sad   uint64
+	Wow   uint64
+}
+
+// CountsMap is the association of an object id to Counts.
+type CountsMap map[uint64]Counts
 
 // List is a collection of Reaction.
 type List []*Reaction
@@ -153,6 +168,7 @@ type Service interface {
 	service.Lifecycle
 
 	Count(namespace string, opts QueryOptions) (uint, error)
+	CountMulti(namespace string, opts QueryOptions) (CountsMap, error)
 	Put(namespace string, reaction *Reaction) (*Reaction, error)
 	Query(namespace string, opts QueryOptions) (List, error)
 }

--- a/service/reaction/sourcing.go
+++ b/service/reaction/sourcing.go
@@ -18,6 +18,10 @@ func (s *sourcingService) Count(ns string, opts QueryOptions) (uint, error) {
 	return s.service.Count(ns, opts)
 }
 
+func (s *sourcingService) CountMulti(ns string, opts QueryOptions) (CountsMap, error) {
+	return s.service.CountMulti(ns, opts)
+}
+
 func (s *sourcingService) Put(ns string, input *Reaction) (new *Reaction, err error) {
 	var old *Reaction
 


### PR DESCRIPTION
Since the introduction of reactions one of the biggest impacts on response times for feed/list requests has been the constant overhead of countless network requests in order to populate counters for posts. This is due the nature how we constructed the service interfaces. In this change-set we introduce a specialised method to get all counts for a list of posts at once. After we verify that this does impact the response times significantly we can mirror the same idea in the cache layer.